### PR TITLE
C++ port of data processor classes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include pypeline/data *

--- a/examples/simulation/lofar_bootes_nufft3.py
+++ b/examples/simulation/lofar_bootes_nufft3.py
@@ -16,11 +16,11 @@ import imot_tools.io.s2image as s2image
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants as constants
-import bluebild
+import finufft
 from imot_tools.io.plot import cmap
 import pypeline.phased_array.beamforming as beamforming
 import pypeline.phased_array.bluebild.data_processor as bb_dp
-from pypeline.phased_array.bluebild.gram import GramMatrix
+import pypeline.phased_array.bluebild.gram as bb_gr
 import pypeline.phased_array.bluebild.field_synthesizer.fourier_domain as bb_synth
 import pypeline.phased_array.bluebild.imager.fourier_domain as bb_im
 import pypeline.phased_array.bluebild.parameter_estimator as bb_pe
@@ -44,6 +44,7 @@ N_station = 24
 dev = instrument.LofarBlock(N_station)
 mb_cfg = [(_, _, field_center) for _ in range(N_station)]
 mb = beamforming.MatchedBeamformerBlock(mb_cfg)
+gram = bb_gr.GramBlock()
 
 # Data generation
 T_integration = 8
@@ -62,15 +63,13 @@ t1 = tt.time()
 N_level = 3
 time_slice = 25
 
-ctx = bluebild.Context(bluebild.ProcessingUnit.AUTO)
-
 ### Intensity Field ===========================================================
 # Parameter Estimation
 I_est = bb_pe.IntensityFieldParameterEstimator(N_level, sigma=0.95)
 for t in ProgressBar(time[::200]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = GramMatrix(data=ctx.gram_matrix(XYZ.data, W.data, wl), beam_idx=W.index[1])
+    G = gram(XYZ, W, wl)
     S = vis(XYZ, W, wl)
     I_est.collect(S, G)
 
@@ -88,9 +87,8 @@ for t in ProgressBar(time[::time_slice]):
     UVW_baselines.append(UVW_baselines_t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-
-    D, V, c_idx = ctx.intensity_field_data(N_eig, XYZ.data, W.data, wl, S.data, c_centroid)
-
+    G = gram(XYZ, W, wl)
+    D, V, c_idx = I_dp(S, G)
     S_corrected = IV_dp(D, V, W, c_idx)
     gram_corrected_visibilities.append(S_corrected)
 
@@ -121,7 +119,7 @@ S_est = bb_pe.SensitivityFieldParameterEstimator(sigma=0.95)
 for t in ProgressBar(time[::200]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = GramMatrix(data=ctx.gram_matrix(XYZ.data, W.data, wl), beam_idx=W.index[1])
+    G = gram(XYZ, W, wl)
 
     S_est.collect(G)
 N_eig = S_est.infer_parameters()
@@ -133,9 +131,8 @@ sensitivity_coeffs = []
 for t in ProgressBar(time[::time_slice]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
-
-    D, V = ctx.sensitivity_field_data(N_eig, XYZ.data, W.data, wl)
-
+    G = gram(XYZ, W, wl)
+    D, V = S_dp(G)
     S_sensitivity = SV_dp(D, V, W, cluster_idx=np.zeros(N_eig, dtype=int))
     sensitivity_coeffs.append(S_sensitivity)
 
@@ -175,4 +172,3 @@ for i in range(lsq_image.shape[0]):
                   catalog_kwargs=dict(s=30, linewidths=0.5, alpha = 0.5), show_gridlines=False)
 
 plt.suptitle(f'Bluebild Eigenmaps')
-#  plt.show()

--- a/examples/simulation/lofar_bootes_nufft3_cpp_data_proc.py
+++ b/examples/simulation/lofar_bootes_nufft3_cpp_data_proc.py
@@ -1,0 +1,178 @@
+# #############################################################################
+# lofar_bootes_nufft.py
+# ======================
+# Author : Matthieu Simeoni [matthieu.simeoni@gmail.com]
+# #############################################################################
+
+"""
+Simulation LOFAR imaging with Bluebild (NUFFT).
+"""
+
+from tqdm import tqdm as ProgressBar
+import astropy.units as u
+import astropy.coordinates as coord
+import astropy.time as atime
+import imot_tools.io.s2image as s2image
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.constants as constants
+import bluebild
+from imot_tools.io.plot import cmap
+import pypeline.phased_array.beamforming as beamforming
+import pypeline.phased_array.bluebild.data_processor as bb_dp
+from pypeline.phased_array.bluebild.gram import GramMatrix
+import pypeline.phased_array.bluebild.field_synthesizer.fourier_domain as bb_synth
+import pypeline.phased_array.bluebild.imager.fourier_domain as bb_im
+import pypeline.phased_array.bluebild.parameter_estimator as bb_pe
+import pypeline.phased_array.data_gen.source as source
+import pypeline.phased_array.instrument as instrument
+import imot_tools.math.sphere.transform as transform
+import pypeline.phased_array.data_gen.statistics as statistics
+from mpl_toolkits.mplot3d import Axes3D
+import imot_tools.io.s2image as im
+import imot_tools.io.plot as implt
+import time as tt
+
+# Observation
+obs_start = atime.Time(56879.54171302732, scale="utc", format="mjd")
+field_center = coord.SkyCoord(ra=218 * u.deg, dec=34.5 * u.deg, frame="icrs")
+FoV, frequency = np.deg2rad(10), 145e6
+wl = constants.speed_of_light / frequency
+
+# Instrument
+N_station = 24
+dev = instrument.LofarBlock(N_station)
+mb_cfg = [(_, _, field_center) for _ in range(N_station)]
+mb = beamforming.MatchedBeamformerBlock(mb_cfg)
+
+# Data generation
+T_integration = 8
+sky_model = source.from_tgss_catalog(field_center, FoV, N_src=40)
+vis = statistics.VisibilityGeneratorBlock(sky_model, T_integration, fs=196000, SNR=30)
+time = obs_start + (T_integration * u.s) * np.arange(3595)
+obs_end = time[-1]
+
+# Imaging
+N_pix = 512
+eps = 1e-3
+w_term = True
+precision = 'single'
+
+t1 = tt.time()
+N_level = 3
+time_slice = 25
+
+ctx = bluebild.Context(bluebild.ProcessingUnit.AUTO)
+
+### Intensity Field ===========================================================
+# Parameter Estimation
+I_est = bb_pe.IntensityFieldParameterEstimator(N_level, sigma=0.95)
+for t in ProgressBar(time[::200]):
+    XYZ = dev(t)
+    W = mb(XYZ, wl)
+    G = GramMatrix(data=ctx.gram_matrix(XYZ.data, W.data, wl), beam_idx=W.index[1])
+    S = vis(XYZ, W, wl)
+    I_est.collect(S, G)
+
+N_eig, c_centroid = I_est.infer_parameters()
+
+# Imaging
+I_dp = bb_dp.IntensityFieldDataProcessorBlock(N_eig, c_centroid)
+IV_dp = bb_dp.VirtualVisibilitiesDataProcessingBlock(N_eig, filters=('lsq', 'sqrt'))
+UVW_baselines = []
+gram_corrected_visibilities = []
+
+for t in ProgressBar(time[::time_slice]):
+    XYZ = dev(t)
+    UVW_baselines_t = dev.baselines(t, uvw=True, field_center=field_center)
+    UVW_baselines.append(UVW_baselines_t)
+    W = mb(XYZ, wl)
+    S = vis(XYZ, W, wl)
+
+    D, V, c_idx = ctx.intensity_field_data(N_eig, XYZ.data, W.data, wl, S.data, c_centroid)
+
+    S_corrected = IV_dp(D, V, W, c_idx)
+    gram_corrected_visibilities.append(S_corrected)
+
+UVW_baselines = np.stack(UVW_baselines, axis=0).reshape(-1, 3)
+gram_corrected_visibilities = np.stack(gram_corrected_visibilities, axis=-3).reshape(*S_corrected.shape[:2], -1)
+
+# fig = plt.figure()
+# # ax = Axes3D(fig)
+# # ax.scatter3D(UVW_baselines[::N_station, 0], UVW_baselines[::N_station, 1], UVW_baselines[::N_station, -1], s=.01)
+# # plt.xlabel('u')
+# # plt.ylabel('v')
+# # ax.set_zlabel('w')
+# plt.figure()
+# plt.scatter(UVW_baselines[:, 0], UVW_baselines[:, 1], s=0.01)
+# plt.xlabel('u')
+# plt.ylabel('v')
+
+# NUFFT Synthesis
+nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, UVW=UVW_baselines.T, grid_size=N_pix, FoV=FoV,
+                                      field_center=field_center, eps=eps, w_term=w_term,
+                                      n_trans=np.prod(gram_corrected_visibilities.shape[:-1]), precision=precision)
+print(nufft_imager._synthesizer._inner_fft_sizes)
+lsq_image, sqrt_image = nufft_imager(gram_corrected_visibilities)
+
+### Sensitivity Field =========================================================
+# Parameter Estimation
+S_est = bb_pe.SensitivityFieldParameterEstimator(sigma=0.95)
+for t in ProgressBar(time[::200]):
+    XYZ = dev(t)
+    W = mb(XYZ, wl)
+    G = GramMatrix(data=ctx.gram_matrix(XYZ.data, W.data, wl), beam_idx=W.index[1])
+
+    S_est.collect(G)
+N_eig = S_est.infer_parameters()
+
+# Imaging
+S_dp = bb_dp.SensitivityFieldDataProcessorBlock(N_eig)
+SV_dp = bb_dp.VirtualVisibilitiesDataProcessingBlock(N_eig, filters=('lsq',))
+sensitivity_coeffs = []
+for t in ProgressBar(time[::time_slice]):
+    XYZ = dev(t)
+    W = mb(XYZ, wl)
+
+    D, V = ctx.sensitivity_field_data(N_eig, XYZ.data, W.data, wl)
+
+    S_sensitivity = SV_dp(D, V, W, cluster_idx=np.zeros(N_eig, dtype=int))
+    sensitivity_coeffs.append(S_sensitivity)
+
+sensitivity_coeffs = np.stack(sensitivity_coeffs, axis=0).reshape(-1)
+nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, UVW=UVW_baselines.T, grid_size=N_pix, FoV=FoV,
+                                      field_center=field_center, eps=eps, w_term=w_term,
+                                      n_trans=1, precision=precision)
+print(nufft_imager._synthesizer._inner_fft_sizes)
+sensitivity_image = nufft_imager(sensitivity_coeffs)
+
+I_lsq_eq = s2image.Image(lsq_image / sensitivity_image, nufft_imager._synthesizer.xyz_grid)
+I_sqrt_eq = s2image.Image(sqrt_image / sensitivity_image, nufft_imager._synthesizer.xyz_grid)
+t2 = tt.time()
+print(f'Elapsed time: {t2 - t1} seconds.')
+
+plt.figure()
+ax = plt.gca()
+I_lsq_eq.draw(catalog=sky_model.xyz.T, ax=ax, data_kwargs=dict(cmap='cubehelix'), show_gridlines=False, catalog_kwargs=dict(s=30, linewidths=0.5, alpha = 0.5))
+ax.set_title(f'Bluebild least-squares, sensitivity-corrected image (NUFFT)\n'
+             f'Bootes Field: {sky_model.intensity.size} sources (simulated), LOFAR: {N_station} stations, FoV: {np.round(FoV * 180 / np.pi)} degrees.\n'
+             f'Run time {np.floor(t2 - t1)} seconds.')
+
+plt.figure()
+ax = plt.gca()
+I_sqrt_eq.draw(catalog=sky_model.xyz.T, ax=ax, data_kwargs=dict(cmap='cubehelix'), show_gridlines=False, catalog_kwargs=dict(s=30, linewidths=0.5, alpha = 0.5))
+ax.set_title(f'Bluebild sqrt, sensitivity-corrected image (NUFFT)\n'
+             f'Bootes Field: {sky_model.intensity.size} sources (simulated), LOFAR: {N_station} stations, FoV: {np.round(FoV * 180 / np.pi)} degrees.\n'
+             f'Run time {np.floor(t2 - t1)} seconds.')
+
+plt.figure()
+titles = ['Strong sources', 'Mild sources', 'Faint Sources']
+for i in range(lsq_image.shape[0]):
+    plt.subplot(1, N_level, i + 1)
+    ax = plt.gca()
+    plt.title(titles[i])
+    I_lsq_eq.draw(index=i, catalog=sky_model.xyz.T, ax=ax, data_kwargs=dict(cmap='cubehelix'),
+                  catalog_kwargs=dict(s=30, linewidths=0.5, alpha = 0.5), show_gridlines=False)
+
+plt.suptitle(f'Bluebild Eigenmaps')
+#  plt.show()

--- a/pypeline/phased_array/beamforming.py
+++ b/pypeline/phased_array/beamforming.py
@@ -71,19 +71,8 @@ def _as_BeamWeights(df):
         .loc[:, ["ROW_ID", "COL_ID", "W"]]
     )
 
-    sparsity_ratio = len(data) / (N_antenna * N_beam)
-    max_sparsity_ratio = pypeline.config.getfloat(
-        "phased_array.beamforming", "bw_max_sparsity_ratio"
-    )
-    if sparsity_ratio <= max_sparsity_ratio:  # Use sparse matrix
-        W = sparse.csr_matrix(
-            (data.W.values, (data.ROW_ID.values, data.COL_ID.values)),
-            shape=(N_antenna, N_beam),
-            dtype=complex,
-        )
-    else:  # Use dense matrix
-        W = np.zeros(shape=(N_antenna, N_beam), dtype=complex)
-        W[data.ROW_ID.values, data.COL_ID.values] = data.W.values
+    W = np.zeros(shape=(N_antenna, N_beam), dtype=complex, order='F')
+    W[data.ROW_ID.values, data.COL_ID.values] = data.W.values
 
     ant_idx = pd.MultiIndex.from_arrays(
         [row_map.STATION_ID, row_map.ANTENNA_ID], names=["STATION_ID", "ANTENNA_ID"]

--- a/pypeline/phased_array/beamforming.py
+++ b/pypeline/phased_array/beamforming.py
@@ -71,8 +71,19 @@ def _as_BeamWeights(df):
         .loc[:, ["ROW_ID", "COL_ID", "W"]]
     )
 
-    W = np.zeros(shape=(N_antenna, N_beam), dtype=complex, order='F')
-    W[data.ROW_ID.values, data.COL_ID.values] = data.W.values
+    sparsity_ratio = len(data) / (N_antenna * N_beam)
+    max_sparsity_ratio = pypeline.config.getfloat(
+        "phased_array.beamforming", "bw_max_sparsity_ratio"
+    )
+    if sparsity_ratio <= max_sparsity_ratio:  # Use sparse matrix
+        W = sparse.csr_matrix(
+            (data.W.values, (data.ROW_ID.values, data.COL_ID.values)),
+            shape=(N_antenna, N_beam),
+            dtype=complex,
+        )
+    else:  # Use dense matrix
+        W = np.zeros(shape=(N_antenna, N_beam), dtype=complex)
+        W[data.ROW_ID.values, data.COL_ID.values] = data.W.values
 
     ant_idx = pd.MultiIndex.from_arrays(
         [row_map.STATION_ID, row_map.ANTENNA_ID], names=["STATION_ID", "ANTENNA_ID"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "wheel",
+    "scikit-build>=0.12",
+    "cmake>=3.10",
+    "make",
+    "pbr"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,10 @@ include_package_data = True
 python_requires = >=3.6
 zip_safe = False
 
-[files]
-packages =
-    pypeline
-data_files =
+# [files]
+# packages =
+#     pypeline
+# data_files =
 #    etc/ = etc/pypeline.cfg
 
 [build_sphinx]

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,15 @@
 Pypeline setup script
 """
 
-from setuptools import setup
+from setuptools import find_packages
+from skbuild import setup
+import os
 
-setup(setup_requires=["pbr"], pbr=True)
+bluebild_gpu = str(os.getenv('BLUEBILD_GPU', 'CUDA'))
+
+setup(setup_requires=["pbr"], pbr=True,
+    packages=(find_packages() + ['bluebild']),
+    package_dir={'bluebild': 'src/bluebild/python/bluebild'},
+    cmake_source_dir='src/bluebild',
+    cmake_args=['-DBLUEBILD_GPU=' + bluebild_gpu],
+)

--- a/src/bluebild/CMakeLists.txt
+++ b/src/bluebild/CMakeLists.txt
@@ -1,0 +1,140 @@
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+project(bluebild LANGUAGES CXX VERSION 0.1.0)
+set(BLUEBILD_SO_VERSION 1)
+set(BLUEBILD_VERSION ${PROJECT_VERSION})
+
+# allow {module}_ROOT variables to be set
+if(POLICY CMP0074)
+	cmake_policy(SET CMP0074 NEW)
+endif()
+
+# use INTERFACE_LINK_LIBRARIES property if available
+if(POLICY CMP0022)
+	cmake_policy(SET CMP0022 NEW)
+endif()
+
+# set default build type to RELEASE
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+		"Debug" "Release" "MinSizeRel" "RelWithDebInfo"
+		)
+endif()
+
+# set language and standard
+set(CMAKE_CXX_STANDARD 17)
+
+# Get GNU standard install prefixes
+include(GNUInstallDirs)
+
+#add local module path
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/modules)
+
+# Options
+option(BLUEBILD_BUILD_TESTS "Build tests" OFF)
+option(BLUEBILD_INSTALL "Enable CMake install commands" ON)
+
+set(BLUEBILD_GPU "OFF" CACHE STRING "GPU backend")
+set_property(CACHE BLUEBILD_GPU PROPERTY STRINGS
+	"OFF" "CUDA" "ROCM"
+	)
+set(BUILD_SHARED_LIBS "ON" CACHE STRING "Build as shared library") # default to shared
+
+# Options combination check
+set(BLUEBILD_CUDA OFF)
+set(BLUEBILD_ROCM OFF)
+if(BLUEBILD_GPU)
+	if(BLUEBILD_GPU STREQUAL "CUDA")
+		set(BLUEBILD_CUDA ON)
+	elseif(BLUEBILD_GPU STREQUAL "ROCM")
+		set(BLUEBILD_ROCM ON)
+	else()
+		message(FATAL_ERROR "Invalid GPU backend")
+	endif()
+endif()
+
+# CUDA
+if(BLUEBILD_CUDA)
+	enable_language(CUDA)
+	if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0") 
+		find_package(CUDAToolkit REQUIRED)
+	else()
+		find_library(CUDA_CUDART_LIBRARY cudart PATHS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+		if(NOT TARGET CUDA::cudart)
+			add_library(CUDA::cudart INTERFACE IMPORTED)
+		endif()
+		set_property(TARGET CUDA::cudart PROPERTY INTERFACE_LINK_LIBRARIES ${CUDA_CUDART_LIBRARY})
+		set_property(TARGET CUDA::cudart PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+
+		find_library(CUDA_CUBLAS_LIBRARY cublas PATHS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+		if(NOT TARGET CUDA::cublas)
+			add_library(CUDA::cublas INTERFACE IMPORTED)
+		endif()
+		set_property(TARGET CUDA::cublas PROPERTY INTERFACE_LINK_LIBRARIES ${CUDA_CUBLAS_LIBRARY})
+		set_property(TARGET CUDA::cublas PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+
+		find_library(CUDA_CUSOLVER_LIBRARY cusolver PATHS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+		if(NOT TARGET CUDA::cusolver)
+			add_library(CUDA::cusolver INTERFACE IMPORTED)
+		endif()
+		set_property(TARGET CUDA::cusolver PROPERTY INTERFACE_LINK_LIBRARIES ${CUDA_CUSOLVER_LIBRARY})
+		set_property(TARGET CUDA::cusolver PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+	endif()
+
+	list(APPEND BLUEBILD_EXTERNAL_LIBS CUDA::cudart CUDA::cublas CUDA::cusolver)
+endif()
+
+# ROCm
+if(BLUEBILD_ROCM)
+	message(FATAL_ERROR "ROCM support not yet fully implemented") # TODO: remove when implemented
+	find_package(hip CONFIG REQUIRED)
+	find_package(rocblas CONFIG REQUIRED)
+  list(APPEND BLUEBILD_EXTERNAL_LIBS hip::host roc::rocblas)
+endif()
+
+set(BLA_SIZEOF_INTEGER 4) # 32 bit interface to blas / lapack
+# BLAS
+find_package(BLAS REQUIRED)
+if(NOT TARGET BLAS::BLAS)
+	# target is only available with CMake 3.18.0 and later
+	add_library(BLAS::BLAS INTERFACE IMPORTED)
+	set_property(TARGET BLAS::BLAS PROPERTY INTERFACE_LINK_LIBRARIES ${BLAS_LIBRARIES} ${BLAS_LINKER_FLAGS})
+endif()
+list(APPEND BLUEBILD_EXTERNAL_LIBS BLAS::BLAS)
+
+# LAPACK
+find_package(LAPACK REQUIRED)
+if(NOT TARGET LAPACK::LAPACK)
+	# target is only available with CMake 3.18.0 and later
+	add_library(LAPACK::LAPACK INTERFACE IMPORTED)
+	set_property(TARGET LAPACK::LAPACK PROPERTY INTERFACE_LINK_LIBRARIES ${LAPACK_LINKER_FLAGS} ${LAPACK_LIBRARIES})
+endif()
+list(APPEND BLUEBILD_EXTERNAL_LIBS LAPACK::LAPACK)
+
+# check if C api is available for blas and lapack
+# include(CheckCXXSymbolExists)
+set(CMAKE_REQUIRED_LIBRARIES ${BLUEBILD_EXTERNAL_LIBS})
+include(CheckFunctionExists)
+
+unset(BLUEBILD_BLAS_C CACHE) # Result is cached, so change of library will not lead to a new check automatically
+CHECK_FUNCTION_EXISTS(cblas_zgemm BLUEBILD_BLAS_C)
+
+unset(BLUEBILD_LAPACK_C CACHE) # Result is cached, so change of library will not lead to a new check automatically
+CHECK_FUNCTION_EXISTS(LAPACKE_zheevx BLUEBILD_LAPACK_C)
+
+# generate config.h
+configure_file(include/bluebild/config.h.in ${PROJECT_BINARY_DIR}/bluebild/config.h)
+
+list(APPEND BLUEBILD_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src)
+list(APPEND BLUEBILD_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include)
+list(APPEND BLUEBILD_INCLUDE_DIRS ${PROJECT_BINARY_DIR})
+
+#############################################################################
+# All include dirs and definitions must be set before sub-directory is added!
+#############################################################################
+add_subdirectory(src)
+
+# add tests for developement
+if(BLUEBILD_BUILD_TESTS)
+	add_subdirectory(tests)
+endif()

--- a/src/bluebild/cmake/BLUEBILDConfig.cmake
+++ b/src/bluebild/cmake/BLUEBILDConfig.cmake
@@ -1,0 +1,5 @@
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/BLUEBILDSharedConfig.cmake")
+	include("${CMAKE_CURRENT_LIST_DIR}/BLUEBILDSharedConfig.cmake")
+else()
+	include("${CMAKE_CURRENT_LIST_DIR}/BLUEBILDStaticConfig.cmake")
+endif()

--- a/src/bluebild/cmake/BLUEBILDConfigVersion.cmake
+++ b/src/bluebild/cmake/BLUEBILDConfigVersion.cmake
@@ -1,0 +1,7 @@
+
+# Prefer shared library
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/BLUEBILDSharedConfigVersion.cmake")
+	include("${CMAKE_CURRENT_LIST_DIR}/BLUEBILDSharedConfigVersion.cmake")
+else()
+	include("${CMAKE_CURRENT_LIST_DIR}/BLUEBILDStaticConfigVersion.cmake")
+endif()

--- a/src/bluebild/cmake/BLUEBILDSharedConfig.cmake
+++ b/src/bluebild/cmake/BLUEBILDSharedConfig.cmake
@@ -1,0 +1,14 @@
+include(CMakeFindDependencyMacro)
+macro(find_dependency_components)
+	if(${ARGV0}_FOUND AND ${CMAKE_VERSION} VERSION_LESS "3.15.0")
+		# find_dependency does not handle new components correctly before 3.15.0
+		set(${ARGV0}_FOUND FALSE)
+	endif()
+	find_dependency(${ARGV})
+endmacro()
+
+# options used for building library
+set(BLUEBILD_GPU @BLUEBILD_GPU@)
+set(BLUEBILD_CUDA @BLUEBILD_CUDA@)
+set(BLUEBILD_ROCM @BLUEBILD_ROCM@)
+

--- a/src/bluebild/cmake/BLUEBILDStaticConfig.cmake
+++ b/src/bluebild/cmake/BLUEBILDStaticConfig.cmake
@@ -1,0 +1,62 @@
+include(CMakeFindDependencyMacro)
+macro(find_dependency_components)
+	if(${ARGV0}_FOUND AND ${CMAKE_VERSION} VERSION_LESS "3.15.0")
+		# find_dependency does not handle new components correctly before 3.15.0
+		set(${ARGV0}_FOUND FALSE)
+	endif()
+	find_dependency(${ARGV})
+endmacro()
+
+# Only look for modules we installed and save value
+set(_CMAKE_MODULE_PATH_SAVE ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
+
+# options used for building library
+set(BLUEBILD_GPU @BLUEBILD_GPU@)
+set(BLUEBILD_CUDA @BLUEBILD_CUDA@)
+set(BLUEBILD_ROCM @BLUEBILD_ROCM@)
+
+if(BLUEBILD_ROCM)
+	find_dependency(hip CONFIG)
+	find_dependency(rocblas CONFIG)
+endif()
+
+
+if(BLUEBILD_CUDA)
+	if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0") 
+		find_dependency(CUDAToolkit)
+	else()
+		enable_language(CUDA)
+		find_library(CUDA_CUDART_LIBRARY cudart PATHS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+		if(NOT TARGET CUDA::cudart)
+			add_library(CUDA::cudart INTERFACE IMPORTED)
+		endif()
+		set_property(TARGET CUDA::cudart PROPERTY INTERFACE_LINK_LIBRARIES ${CUDA_CUDART_LIBRARY})
+		set_property(TARGET CUDA::cudart PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+
+		find_library(CUDA_CUBLAS_LIBRARY cublas PATHS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+		if(NOT TARGET CUDA::cublas)
+			add_library(CUDA::cublas INTERFACE IMPORTED)
+		endif()
+		set_property(TARGET CUDA::cublas PROPERTY INTERFACE_LINK_LIBRARIES ${CUDA_CUBLAS_LIBRARY})
+		set_property(TARGET CUDA::cublas PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+	endif()
+endif()
+
+find_dependency(BLAS)
+if(NOT TARGET BLAS::blas)
+	# target is only available with CMake 3.18.0 and later
+	add_library(BLAS::blas INTERFACE IMPORTED)
+	set_property(TARGET BLAS::blas PROPERTY INTERFACE_LINK_LIBRARIES ${BLAS_LIBRARIES} ${BLAS_LINKER_FLAGS})
+endif()
+
+set(CMAKE_MODULE_PATH ${_CMAKE_MODULE_PATH_SAVE}) # restore module path
+
+# find_dependency may set BLUEBILD_FOUND to false, so only add bluebild if everything required was found
+if(NOT DEFINED BLUEBILD_FOUND OR BLUEBILD_FOUND)
+	# add version of package
+	include("${CMAKE_CURRENT_LIST_DIR}/BLUEBILDStaticConfigVersion.cmake")
+
+	# add library target
+	include("${CMAKE_CURRENT_LIST_DIR}/BLUEBILDStaticTargets.cmake")
+endif()

--- a/src/bluebild/cmake/BLUEBILDTargets.cmake
+++ b/src/bluebild/cmake/BLUEBILDTargets.cmake
@@ -1,0 +1,7 @@
+
+# Prefer shared library
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/BLUEBILDSharedTargets.cmake")
+	include("${CMAKE_CURRENT_LIST_DIR}/BLUEBILDSharedTargets.cmake")
+else()
+	include("${CMAKE_CURRENT_LIST_DIR}/BLUEBILDStaticTargets.cmake")
+endif()

--- a/src/bluebild/include/bluebild/bluebild.h
+++ b/src/bluebild/include/bluebild/bluebild.h
@@ -1,0 +1,228 @@
+#pragma once
+
+#include "bluebild/config.h"
+#include "bluebild/errors.h"
+
+enum BluebildProcessingUnit { BLUEBILD_PU_AUTO, BLUEBILD_PU_CPU, BLUEBILD_PU_GPU };
+
+#ifndef __cplusplus
+/*! \cond PRIVATE */
+// C only
+typedef enum BluebildProcessingUnit BluebildProcessingUnit;
+/*! \endcond */
+#endif  // cpp
+
+typedef void* BluebildContext;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Create a context.
+ *
+ * @param[in] pu Processing unit to use. If BLUEBILD_PU_AUTO, GPU will be used if possible, CPU
+ * otherwise.
+ * @param[out] ctx Context handle.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_ctx_create(BluebildProcessingUnit pu, BluebildContext* ctx);
+
+/**
+ * Destroy a context.
+ *
+ * @param[in] ctx Context handle.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_ctx_destroy(BluebildContext* ctx);
+
+/**
+ * Compute the positive eigenvalues and eigenvectors of a hermitian matrix in single precision.
+ * Optionally solves a general eigenvalue problem.
+ *
+ * @param[in] ctx Context handle.
+ * @param[in] m Order of matrix A.
+ * @param[in] nEig Maximum number of eigenvalues to compute.
+ * @param[in] a Hermitian matrix A. Only the lower triangle is read.
+ * @param[in] lda Leading dimension of A.
+ * @param[in] b Matrix B. Optional. When not null, a general eigenvalue problem is solved.
+ * @param[in] ldb Leading dimension of B.
+ * @param[out] nEigOut Number of positive eigenvalues found.
+ * @param[out] d Eigenvalues.
+ * @param[out] v Eigenvectors stored as Matrix coloumns.
+ * @param[out] ldv Leading of V.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_eigh_s(BluebildContext ctx, int m,
+                                              int nEig, const void *a, int lda,
+                                              const void *b, int ldb,
+                                              int *nEigOut, float *d, void *v,
+                                              int ldv);
+
+/**
+ * Compute the positive eigenvalues and eigenvectors of a hermitian matrix in double precision.
+ * Optionally solves a general eigenvalue problem.
+ *
+ * @param[in] ctx Context handle.
+ * @param[in] m Order of matrix A.
+ * @param[in] nEig Maximum number of eigenvalues to compute.
+ * @param[in] a Matrix A.
+ * @param[in] lda Leading dimension of A.
+ * @param[in] b Matrix B. Optional. When not null, a general eigenvalue problem is solved.
+ * @param[in] ldb Leading dimension of B.
+ * @param[out] nEigOut Number of positive eigenvalues found.
+ * @param[out] d Eigenvalues.
+ * @param[out] v Eigenvectors stored as Matrix coloumns.
+ * @param[out] ldv Leading of V.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_eigh_d(BluebildContext ctx, int m, int nEig, const void* a,
+                                             int lda, const void* b, int ldb, int* nEigOut,
+                                             double* d, void* v, int ldv);
+
+/**
+ * fPCA decomposition and data formatting for intensity field in single precision.
+ *
+ * @param[in] ctx Context handle.
+ * @param[in] wl Wavelength for which to compute the gram matrix
+ * @param[in] m Number of antenna.
+ * @param[in] n Number of beams.
+ * @param[in] nEig Number of requested eigenvalues.
+ * @param[in] s Visibility matrix.
+ * @param[in] lds Leading dimension of S.
+ * @param[in] w Beamforming matrix.
+ * @param[in] ldw Leading dimension of W.
+ * @param[in] xyz Three dimensional antenna coordinates, where each coloumn represents one
+ * dimension.
+ * @param[in] ldxyz Leading dimension of xyz.
+ * @param[out] d Eigenvalues.
+ * @param[out] v Eigenvectors stored as Matrix coloumns.
+ * @param[out] ldv Leading of V.
+ * @param[out] nCluster Number of eigenpairs to output after PCA decomposition.
+ * @param[in] cluster Intensity centroids for energy-level clustering.
+ * @param[out] clusterIndices Cluster indices of each eigenpair.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_intensity_field_data_s(
+    BluebildContext ctx, float wl, int m, int n, int nEig, const void* s, int lds, const void* w,
+    int ldw, const float* xyz, int ldxyz, float* d, void* v, int ldv, int nCluster,
+    const float* cluster, int* clusterIndices);
+
+/**
+ * fPCA decomposition and data formatting for intensity field in double precision.
+ *
+ * @param[in] ctx Context handle.
+ * @param[in] wl Wavelength for which to compute the gram matrix
+ * @param[in] m Number of antenna.
+ * @param[in] n Number of beams.
+ * @param[in] nEig Number of requested eigenvalues.
+ * @param[in] s Visibility matrix.
+ * @param[in] lds Leading dimension of S.
+ * @param[in] w Beamforming matrix.
+ * @param[in] ldw Leading dimension of W.
+ * @param[in] xyz Three dimensional antenna coordinates, where each coloumn represents one
+ * dimension.
+ * @param[in] ldxyz Leading dimension of xyz.
+ * @param[out] d Eigenvalues.
+ * @param[out] v Eigenvectors stored as Matrix coloumns.
+ * @param[out] ldv Leading of V.
+ * @param[out] nCluster Number of eigenpairs to output after PCA decomposition.
+ * @param[in] cluster Intensity centroids for energy-level clustering.
+ * @param[out] clusterIndices Cluster indices of each eigenpair.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_intensity_field_data_d(
+    BluebildContext ctx, double wl, int m, int n, int nEig, const void* s, int lds, const void* w,
+    int ldw, const double* xyz, int ldxyz, double* d, void* v, int ldv, int nCluster,
+    const double* cluster, int* clusterIndices);
+
+/**
+ * Data processor for computing sensitivity fields in single precision.
+ *
+ * @param[in] ctx Context handle.
+ * @param[in] wl Wavelength for which to compute the gram matrix
+ * @param[in] m Number of antenna.
+ * @param[in] n Number of beams.
+ * @param[in] nEig Number of requested eigenvalues.
+ * @param[in] w Beamforming matrix.
+ * @param[in] ldw Leading dimension of W.
+ * @param[in] xyz Three dimensional antenna coordinates, where each coloumn represents one
+ * dimension.
+ * @param[in] ldxyz Leading dimension of xyz.
+ * @param[out] d Eigenvalues.
+ * @param[out] v Eigenvectors stored as Matrix coloumns.
+ * @param[out] ldv Leading of V.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_sensitivity_field_data_s(BluebildContext ctx, float wl,
+                                                                int m, int n, int nEig, void* w,
+                                                                int ldw, const float* xyz,
+                                                                int ldxyz, float* d, void* v,
+                                                                int ldv);
+
+/**
+ * Data processor for computing sensitivity fields in double precision.
+ *
+ * @param[in] ctx Context handle.
+ * @param[in] wl Wavelength for which to compute the gram matrix
+ * @param[in] m Number of antenna.
+ * @param[in] n Number of beams.
+ * @param[in] nEig Number of requested eigenvalues.
+ * @param[in] w Beamforming matrix.
+ * @param[in] ldw Leading dimension of W.
+ * @param[in] xyz Three dimensional antenna coordinates, where each coloumn represents one
+ * dimension.
+ * @param[in] ldxyz Leading dimension of xyz.
+ * @param[out] d Eigenvalues.
+ * @param[out] v Eigenvectors stored as Matrix coloumns.
+ * @param[out] ldv Leading of V.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_sensitivity_field_data_d(BluebildContext ctx, double wl,
+                                                                int m, int n, int nEig, void* w,
+                                                                int ldw, const double* xyz,
+                                                                int ldxyz, double* d, void* v,
+                                                                int ldv);
+
+/**
+ * Data processor for the gram matrix in single precision.
+ *
+ * @param[in] ctx Context handle.
+ * @param[in] m Number of antenna.
+ * @param[in] n Number of beams.
+ * @param[in] w Beamforming matrix.
+ * @param[in] ldw Leading dimension of W.
+ * @param[in] xyz Three dimensional antenna coordinates, where each coloumn represents one
+ * dimension.
+ * @param[in] ldxyz Leading dimension of xyz.
+ * @param[in] wl Wavelength for which to compute the gram matrix.
+ * @param[out] g Gram matrix.
+ * @param[out] ldg Leading of G.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_gram_matrix_s(BluebildContext ctx, int m, int n,
+                                                     const void* w, int ldw, const float* xyz,
+                                                     int ldxyz, float wl, void* g, int ldg);
+
+/**
+ * Data processor for the gram matrix in double precision.
+ *
+ * @param[in] ctx Context handle.
+ * @param[in] m Number of antenna.
+ * @param[in] n Number of beams.
+ * @param[in] w Beamforming matrix.
+ * @param[in] ldw Leading dimension of W.
+ * @param[in] xyz Three dimensional antenna coordinates, where each coloumn represents one
+ * dimension.
+ * @param[in] ldxyz Leading dimension of xyz.
+ * @param[in] wl Wavelength for which to compute the gram matrix.
+ * @param[out] g Gram matrix.
+ * @param[out] ldg Leading of G.
+ * @return Error code or BLUEBILD_SUCCESS.
+ */
+BLUEBILD_EXPORT BluebildError bluebild_gram_matrix_d(BluebildContext ctx, int m, int n,
+                                                     const void* w, int ldw, const double* xyz,
+                                                     int ldxyz, double wl, void* g, int ldg);
+#ifdef __cplusplus
+}
+#endif

--- a/src/bluebild/include/bluebild/config.h.in
+++ b/src/bluebild/include/bluebild/config.h.in
@@ -1,0 +1,9 @@
+#pragma once
+
+#cmakedefine BLUEBILD_CUDA
+#cmakedefine BLUEBILD_ROCM
+#cmakedefine BLUEBILD_BLAS_C
+#cmakedefine BLUEBILD_LAPACK_C
+
+#include "bluebild/bluebild_export.h"
+

--- a/src/bluebild/include/bluebild/errors.h
+++ b/src/bluebild/include/bluebild/errors.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "bluebild/config.h"
+
+enum BluebildError {
+  /**
+   * Success. No error.
+   */
+  BLUEBILD_SUCCESS,
+  /**
+   * Unknown error.
+   */
+  BLUEBILD_UNKNOWN_ERROR,
+  /**
+   * Internal error.
+   */
+  BLUEBILD_INTERNAL_ERROR,
+  /**
+   * Invalid parameter error.
+   */
+  BLUEBILD_INVALID_PARAMETER_ERROR,
+  /**
+   * Invalid pointer error.
+   */
+  BLUEBILD_INVALID_POINTER_ERROR,
+  /**
+   * Invalid handle error.
+   */
+  BLUEBILD_INVALID_HANDLE_ERROR,
+  /**
+   * Eigensolver error.
+   */
+  BLUEBILD_EIGENSOLVER_ERROR,
+  /**
+   * Not Implemented error.
+   */
+  BLUEBILD_NOT_IMPLEMENTED_ERROR,
+  /**
+   * GPU error.
+   */
+  BLUEBILD_GPU_ERROR,
+  /**
+   * GPU support error.
+   */
+  BLUEBILD_GPU_SUPPORT_ERROR,
+  /**
+   * GPU allocation error.
+   */
+  BLUEBILD_GPU_ALLOCATION_ERROR,
+  /**
+   * GPU launch error.
+   */
+  BLUEBILD_GPU_LAUNCH_ERROR,
+  /**
+   * GPU no device error.
+   */
+  BLUEBILD_GPU_NO_DEVICE_ERROR,
+  /**
+   * GPU invalid value error.
+   */
+  BLUEBILD_GPU_INVALID_VALUE_ERROR,
+  /**
+   * Invalid device pointer error.
+   */
+  BLUEBILD_GPU_INVALID_DEVICE_POINTER_ERROR,
+  /**
+   * GPU blas error.
+   */
+  BLUEBILD_GPU_BLAS_ERROR,
+  /**
+   * Invalid allocator function error.
+   */
+  BLUEBILD_INVALID_ALLOCATOR_FUNCTION
+};
+
+#ifndef __cplusplus
+/*! \cond PRIVATE */
+// C only
+typedef enum BluebildError BluebildError;
+/*! \endcond */
+#endif  // cpp

--- a/src/bluebild/include/bluebild/exceptions.hpp
+++ b/src/bluebild/include/bluebild/exceptions.hpp
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <stdexcept>
+
+#include "bluebild/config.h"
+#include "bluebild/errors.h"
+
+namespace bluebild {
+
+/**
+ * A generic error. Base type for all other exceptions.
+ */
+class BLUEBILD_EXPORT GenericError : public std::exception {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: Generic error"; }
+
+  virtual BluebildError error_code() const noexcept {
+    return BluebildError::BLUEBILD_UNKNOWN_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT InternalError : public GenericError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: Internal error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_INTERNAL_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT InvalidParameterError : public GenericError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: Invalid parameter error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_INVALID_PARAMETER_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT InvalidPointerError : public GenericError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: Invalid pointer error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_INVALID_POINTER_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT InvalidAllocatorFunctionError : public GenericError {
+public:
+  const char* what() const noexcept override {
+    return "BLUEBILD: Invalid allocator function error";
+  }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_INVALID_ALLOCATOR_FUNCTION;
+  }
+};
+
+class BLUEBILD_EXPORT EigensolverError : public GenericError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: Eigensolver error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_EIGENSOLVER_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT NotImplementedError : public GenericError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: Not implemented"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_NOT_IMPLEMENTED_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT GPUError : public GenericError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: GPU error"; }
+
+  BluebildError error_code() const noexcept override { return BluebildError::BLUEBILD_GPU_ERROR; }
+};
+
+class BLUEBILD_EXPORT GPUSupportError : public GPUError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: Not compiled with GPU support"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_GPU_SUPPORT_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT GPUAllocationError : public GPUError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: GPU allocation error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_GPU_ALLOCATION_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT GPULaunchError : public GPUError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: GPU launch error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_GPU_LAUNCH_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT GPUNoDeviceError : public GPUError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: GPU no device error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_GPU_NO_DEVICE_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT GPUInvalidValueError : public GPUError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: GPU invalid value error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_GPU_INVALID_VALUE_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT GPUInvalidDevicePointerError : public GPUError {
+public:
+  const char* what() const noexcept override {
+    return "BLUEBILD: GPU invalid device pointer error";
+  }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_GPU_INVALID_DEVICE_POINTER_ERROR;
+  }
+};
+
+class BLUEBILD_EXPORT GPUBlasError : public GPUError {
+public:
+  const char* what() const noexcept override { return "BLUEBILD: GPU BLAS error"; }
+
+  BluebildError error_code() const noexcept override {
+    return BluebildError::BLUEBILD_GPU_BLAS_ERROR;
+  }
+};
+
+}  // namespace bluebild

--- a/src/bluebild/python/bluebild/__init__.py
+++ b/src/bluebild/python/bluebild/__init__.py
@@ -1,0 +1,445 @@
+#  from bluebild.bluebild import bluebild
+
+__all__ = ["bluebild"]
+__version__ = "0.1"
+
+import numpy as np
+from enum import IntEnum
+import ctypes
+from pathlib import Path
+from ctypes import c_void_p, c_int, c_float, c_double
+import platform
+
+if platform.system() == 'Darwin':
+    _bluebild_lib_name = 'libbluebild.dylib'
+else:
+    _bluebild_lib_name = 'libbluebild.so'
+
+_bluebild_lib_paths = ['', 'lib', 'lib64', '../', '../lib', '../lib64', '../..', '../../lib', '../../lib64', '../../..', '../../../lib', '../../../lib64']
+
+_bluebild_lib = None
+_bluebild_module_loc = str(Path(__file__).absolute().parent.as_posix())
+
+# try to find library installed with module
+for p in _bluebild_lib_paths:
+    if _bluebild_lib:
+        break
+    try:
+        _bluebild_lib = ctypes.cdll.LoadLibrary(_bluebild_module_loc + '/' + p + '/' + _bluebild_lib_name)
+    except Exception:
+        pass
+
+# try to find library in default system shared library search paths as fallback
+if not _bluebild_lib:
+    try:
+        _bluebild_lib = ctypes.cdll.LoadLibrary(_bluebild_lib_name)
+    except Exception:
+        raise RuntimeError("Failed to find bluebild library")
+
+
+_bluebild_ctx_create = _bluebild_lib.bluebild_ctx_create
+_bluebild_ctx_create.argtypes = [c_int, ctypes.POINTER(c_void_p)]
+_bluebild_ctx_create.restypes = c_int
+
+_bluebild_ctx_destroy = _bluebild_lib.bluebild_ctx_destroy
+_bluebild_ctx_destroy.argtypes = [ctypes.POINTER(c_void_p)]
+_bluebild_ctx_destroy.restypes = c_int
+
+_bluebild_eigh_s = _bluebild_lib.bluebild_eigh_s
+_bluebild_eigh_s.argtypes = [
+    c_void_p,
+    c_int,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_void_p,
+    c_void_p,
+    c_int,
+]
+_bluebild_eigh_s.restypes = c_int
+
+_bluebild_eigh_d = _bluebild_lib.bluebild_eigh_d
+_bluebild_eigh_d.argtypes = [
+    c_void_p,
+    c_int,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_void_p,
+    c_void_p,
+    c_int,
+]
+_bluebild_eigh_d.restypes = c_int
+
+_bluebild_sensitivity_field_data_s = _bluebild_lib.bluebild_sensitivity_field_data_s
+_bluebild_sensitivity_field_data_s.argtypes = [
+    c_void_p,
+    c_float,
+    c_int,
+    c_int,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_void_p,
+    c_int,
+]
+_bluebild_sensitivity_field_data_s.restypes = c_int
+
+_bluebild_sensitivity_field_data_d = _bluebild_lib.bluebild_sensitivity_field_data_d
+_bluebild_sensitivity_field_data_d.argtypes = [
+    c_void_p,
+    c_double,
+    c_int,
+    c_int,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_void_p,
+    c_int,
+]
+_bluebild_sensitivity_field_data_d.restypes = c_int
+
+_bluebild_intensity_field_data_s = _bluebild_lib.bluebild_intensity_field_data_s
+_bluebild_intensity_field_data_s.argtypes = [
+    c_void_p,
+    c_float,
+    c_int,
+    c_int,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_void_p,
+    c_int,
+    c_int,
+    c_void_p,
+    c_void_p,
+]
+_bluebild_intensity_field_data_s.restypes = c_int
+
+_bluebild_intensity_field_data_d = _bluebild_lib.bluebild_intensity_field_data_d
+_bluebild_intensity_field_data_d.argtypes = [
+    c_void_p,
+    c_double,
+    c_int,
+    c_int,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_void_p,
+    c_int,
+    c_int,
+    c_void_p,
+    c_void_p,
+]
+_bluebild_intensity_field_data_d.restypes = c_int
+
+_bluebild_gram_matrix_s = _bluebild_lib.bluebild_gram_matrix_s
+_bluebild_gram_matrix_s.argtypes = [
+    c_void_p,
+    c_int,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_float,
+    c_void_p,
+    c_int,
+]
+_bluebild_gram_matrix_s.restypes = c_int
+
+_bluebild_gram_matrix_d = _bluebild_lib.bluebild_gram_matrix_d
+_bluebild_gram_matrix_d.argtypes = [
+    c_void_p,
+    c_int,
+    c_int,
+    c_void_p,
+    c_int,
+    c_void_p,
+    c_int,
+    c_double,
+    c_void_p,
+    c_int,
+]
+_bluebild_gram_matrix_d.restypes = c_int
+
+
+class ProcessingUnit(IntEnum):
+    AUTO = 0
+    CPU = 1
+    GPU = 2
+
+
+class Context:
+    def __init__(self, pu=ProcessingUnit.AUTO):
+        self.ctx = ctypes.c_void_p(None)
+        ier = _bluebild_ctx_create(int(pu), ctypes.byref(self.ctx))
+        if ier != 0:
+            raise RuntimeError("Bluebild: Failed to create context.")
+
+    def __del__(self):
+        if self.ctx:
+            ier = _bluebild_ctx_destroy(ctypes.byref(self.ctx))
+            if ier != 0:
+                raise RuntimeError("Bluebild: Failed to destroy context.")
+
+    def eigh(self, A, B=None, n_eig=0):
+        if len(A.shape) != 2:
+            raise RuntimeError("Bluebild: Input must be 2 dimensional.")
+
+        if A.shape[0] != A.shape[1]:
+            raise RuntimeError("Bluebild: A must be symmetrical.")
+
+        if n_eig == 0:
+            n_eig = A.shape[1]
+
+        # make sure input is in coloumn major order
+        if A.strides[0] != A.itemsize:
+            A = np.array(A, order="F")
+        if B is not None and B.strides[0] != B.itemsize:
+            B = np.array(B, order="F")
+
+        V = np.empty([A.shape[0], n_eig], order="F", dtype=A.dtype)
+        D = np.empty(
+            n_eig,
+            order="F",
+            dtype=np.float32 if A.dtype == np.complex64 else np.float64,
+        )
+
+        b_ptr = ctypes.c_void_p(0)
+        ldb = 0
+        if B is not None:
+            b_ptr = B.ctypes.data
+            ldb = int(B.strides[1] / B.itemsize)
+
+        n_eig_out = ctypes.c_int(0)
+        if A.dtype == np.complex64:
+            _bluebild_eigh_s(
+                self.ctx,
+                A.shape[0],
+                n_eig,
+                A.ctypes.data,
+                int(A.strides[1] / A.itemsize),
+                b_ptr,
+                ldb,
+                ctypes.byref(n_eig_out),
+                D.ctypes.data,
+                V.ctypes.data,
+                int(V.strides[1] / V.itemsize),
+            )
+        elif A.dtype == np.complex128:
+            _bluebild_eigh_d(
+                self.ctx,
+                A.shape[0],
+                n_eig,
+                A.ctypes.data,
+                int(A.strides[1] / A.itemsize),
+                b_ptr,
+                ldb,
+                ctypes.byref(n_eig_out),
+                D.ctypes.data,
+                V.ctypes.data,
+                int(V.strides[1] / V.itemsize),
+            )
+        else:
+            raise TypeError("Bluebild: Input type must be complex.")
+
+        return n_eig_out, D, V
+
+    def sensitivity_field_data(self, n_eig, XYZ, W, wl):
+        n_antenna = XYZ.shape[0]
+        n_beam = W.shape[1]
+
+        V = np.empty([n_beam, n_eig], order="F", dtype=W.dtype)
+        D = np.empty(
+            n_eig,
+            order="F",
+            dtype=np.float32 if W.dtype == np.complex64 else np.float64,
+        )
+
+        # make sure input is in coloumn major order
+        if XYZ.strides[0] != XYZ.itemsize:
+            XYZ = np.array(XYZ, order="F")
+        if W.strides[0] != W.itemsize:
+            W = np.array(W, order="F")
+
+        if W.dtype == np.complex64:
+            ier = _bluebild_sensitivity_field_data_s(
+                self.ctx,
+                wl,
+                n_antenna,
+                n_beam,
+                n_eig,
+                W.ctypes.data,
+                int(W.strides[1] / W.itemsize),
+                XYZ.ctypes.data,
+                int(XYZ.strides[1] / XYZ.itemsize),
+                D.ctypes.data,
+                V.ctypes.data,
+                int(V.strides[1] / V.itemsize),
+            )
+        elif W.dtype == np.complex128:
+            ier = _bluebild_sensitivity_field_data_d(
+                self.ctx,
+                wl,
+                n_antenna,
+                n_beam,
+                n_eig,
+                W.ctypes.data,
+                int(W.strides[1] / W.itemsize),
+                XYZ.ctypes.data,
+                int(XYZ.strides[1] / XYZ.itemsize),
+                D.ctypes.data,
+                V.ctypes.data,
+                int(V.strides[1] / V.itemsize),
+            )
+        else:
+            raise TypeError("Bluebild: Input type must be complex.")
+
+        if ier != 0:
+            raise RuntimeError("Bluebild: Failed to execute.")
+        return D, V
+
+    def intensity_field_data(self, n_eig, XYZ, W, wl, S, centroids):
+        n_antenna = XYZ.shape[0]
+        n_beam = W.shape[1]
+
+        V = np.empty([S.shape[0], n_eig], order="F", dtype=S.dtype)
+        D = np.empty(
+            n_eig,
+            order="F",
+            dtype=np.float32 if S.dtype == np.complex64 else np.float64,
+        )
+
+        # make sure input is in coloumn major order
+        if S.strides[0] != S.itemsize:
+            S = np.array(S, order="F")
+        if XYZ.strides[0] != XYZ.itemsize:
+            XYZ = np.array(XYZ, order="F")
+        if W.strides[0] != W.itemsize:
+            W = np.array(W, order="F")
+        if centroids.strides[0] != centroids.itemsize:
+            centroids = np.array(centroids, order="F")
+
+        cluster_idx = np.empty(n_eig, order="F", dtype=np.intc)
+
+        if S.dtype == np.complex64:
+            ier = _bluebild_intensity_field_data_s(
+                self.ctx,
+                wl,
+                n_antenna,
+                n_beam,
+                n_eig,
+                S.ctypes.data,
+                int(S.strides[1] / S.itemsize),
+                W.ctypes.data,
+                int(W.strides[1] / W.itemsize),
+                XYZ.ctypes.data,
+                int(XYZ.strides[1] / XYZ.itemsize),
+                D.ctypes.data,
+                V.ctypes.data,
+                int(V.strides[1] / V.itemsize),
+                len(centroids),
+                centroids.ctypes.data,
+                cluster_idx.ctypes.data,
+            )
+        elif S.dtype == np.complex128:
+            ier = _bluebild_intensity_field_data_d(
+                self.ctx,
+                wl,
+                n_antenna,
+                n_beam,
+                n_eig,
+                S.ctypes.data,
+                int(S.strides[1] / S.itemsize),
+                W.ctypes.data,
+                int(W.strides[1] / W.itemsize),
+                XYZ.ctypes.data,
+                int(XYZ.strides[1] / XYZ.itemsize),
+                D.ctypes.data,
+                V.ctypes.data,
+                int(V.strides[1] / V.itemsize),
+                len(centroids),
+                centroids.ctypes.data,
+                cluster_idx.ctypes.data,
+            )
+        else:
+            raise TypeError("Bluebild: Input type must be complex.")
+
+        if ier != 0:
+            raise RuntimeError("Bluebild: Failed to execute.")
+
+        return D, V, cluster_idx
+
+    def gram_matrix(self, XYZ, W, wl):
+        N_antenna = XYZ.shape[0]
+        N_beam = W.shape[1]
+        G = np.empty(
+            [N_beam, N_beam],
+            order="F",
+            dtype=np.complex64 if XYZ.dtype == np.float32 else np.complex128,
+        )
+
+        # make sure input is in coloumn major order
+        if XYZ.strides[0] != XYZ.itemsize:
+            XYZ = np.array(XYZ, order="F")
+        if W.strides[0] != W.itemsize:
+            W = np.array(W, order="F")
+
+        if XYZ.dtype == np.float32:
+            wl = np.float32(wl)
+            ier = _bluebild_gram_matrix_s(
+                self.ctx,
+                N_antenna,
+                N_beam,
+                W.ctypes.data,
+                int(W.strides[1] / W.itemsize),
+                XYZ.ctypes.data,
+                int(XYZ.strides[1] / XYZ.itemsize),
+                wl,
+                G.ctypes.data,
+                int(G.strides[1] / G.itemsize),
+            )
+        elif XYZ.dtype == np.float64:
+            wl = np.float64(wl)
+            ier = _bluebild_gram_matrix_d(
+                self.ctx,
+                N_antenna,
+                N_beam,
+                W.ctypes.data,
+                int(W.strides[1] / W.itemsize),
+                XYZ.ctypes.data,
+                int(XYZ.strides[1] / XYZ.itemsize),
+                wl,
+                G.ctypes.data,
+                int(G.strides[1] / G.itemsize),
+            )
+        else:
+            raise TypeError("Bluebild: Input type must be scalar.")
+
+        if ier != 0:
+            raise RuntimeError("Bluebild: Failed to execute.")
+        return G
+

--- a/src/bluebild/src/CMakeLists.txt
+++ b/src/bluebild/src/CMakeLists.txt
@@ -1,0 +1,143 @@
+set(BLUEBILD_SOURCE_FILES
+	eigensolver.cpp
+	gram_matrix.cpp
+	intensitiy_field_data.cpp
+	sensitivity_field_data.cpp
+	context.cpp
+	host/eigensolver_host.cpp
+	host/gram_matrix_host.cpp
+	host/sensitivity_field_data_host.cpp
+	host/intensity_field_data_host.cpp
+	)
+
+if(BLUEBILD_CUDA OR BLUEBILD_ROCM)
+	list(APPEND BLUEBILD_SOURCE_FILES
+		gpu/eigensolver_gpu.cpp
+		gpu/sensitivity_field_data_gpu.cpp
+		gpu/intensity_field_data_gpu.cpp
+		gpu/gram_matrix_gpu.cpp
+		gpu/kernels/reverse.cu
+		gpu/kernels/inv_square.cu
+		gpu/kernels/min_diff.cu
+		gpu/kernels/gram.cu
+		)
+endif()
+
+
+# Creates bluebild library with given name. All common target modifications should be done here.
+macro(bluebild_create_library _TARGET_NAME)
+	add_library(${_TARGET_NAME} ${BLUEBILD_LIBRARY_TYPE}
+		${BLUEBILD_SOURCE_FILES}
+		)
+
+	set_property(TARGET ${_TARGET_NAME} PROPERTY VERSION ${BLUEBILD_VERSION})
+	set_property(TARGET ${_TARGET_NAME} PROPERTY SOVERSION ${BLUEBILD_SO_VERSION})
+
+
+	# Don't export any symbols of external static libaries. Only works on linux.
+	if(UNIX AND NOT APPLE)
+		if(${CMAKE_VERSION} VERSION_LESS "3.13.5") 
+			target_link_libraries(${_TARGET_NAME} PRIVATE "-Wl,--exclude-libs,ALL")
+		else()
+			target_link_options(${_TARGET_NAME} PRIVATE "-Wl,--exclude-libs,ALL")
+		endif()
+	endif()
+
+	# All .cu files are self-contained. Device linking can have issues with propageted linker flags of other targets like MPI.
+	if(BLUEBILD_CUDA)
+		set_property(TARGET ${_TARGET_NAME} PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
+		set_property(TARGET ${_TARGET_NAME} PROPERTY CUDA_SEPARABLE_COMPILATION OFF)
+	endif()
+
+	target_compile_options(${_TARGET_NAME} PRIVATE ${BLUEBILD_DEFINITIONS} ${BLUEBILD_EXTERNAL_COMPILE_OPTIONS})
+	target_include_directories(${_TARGET_NAME} PRIVATE ${BLUEBILD_EXTERNAL_INCLUDE_DIRS} ${BLUEBILD_INCLUDE_DIRS})
+
+
+	target_link_libraries(${_TARGET_NAME} PRIVATE ${BLUEBILD_EXTERNAL_LIBS})
+
+	target_include_directories(${_TARGET_NAME} INTERFACE ${BLUEBILD_INTERFACE_INCLUDE_DIRS})
+	target_include_directories(${_TARGET_NAME} INTERFACE $<INSTALL_INTERFACE:include>) # for install(EXPORT ...)
+	target_include_directories(${_TARGET_NAME} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>) # for export(...)
+
+endmacro()
+
+bluebild_create_library(bluebild)
+set_target_properties(bluebild PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE CXX_VISIBILITY_PRESET hidden)
+
+if(BLUEBILD_BUILD_TESTS)
+	# create library with default visibility if tests are build, to allow linking to internal symbols
+	bluebild_create_library(bluebild_test)
+	set_target_properties(bluebild_test PROPERTIES VISIBILITY_INLINES_HIDDEN FALSE CXX_VISIBILITY_PRESET default)
+	target_compile_options(bluebild_test PUBLIC -DBLUEBILD_STATIC_DEFINE)
+	# enable internal timings
+	target_compile_options(bluebild_test PUBLIC -DBLUEBILD_TIMING)
+endif()
+
+# generate export header to control symbol visibility
+include(GenerateExportHeader)
+generate_export_header(bluebild)
+configure_file("${CMAKE_CURRENT_BINARY_DIR}/bluebild_export.h"
+	"${PROJECT_BINARY_DIR}/bluebild/bluebild_export.h"
+	COPYONLY
+)
+
+# set packge config names
+get_target_property(_LIB_TYPE bluebild TYPE)
+if(_LIB_TYPE STREQUAL "STATIC_LIBRARY")
+	set(BLUEBILD_VERSION_FILE "BLUEBILDStaticConfigVersion.cmake")
+	set(BLUEBILD_CONFIG_FILE "BLUEBILDStaticConfig.cmake")
+	set(BLUEBILD_TARGETS_FILE "BLUEBILDStaticTargets.cmake")
+else()
+	set(BLUEBILD_VERSION_FILE "BLUEBILDSharedConfigVersion.cmake")
+	set(BLUEBILD_CONFIG_FILE "BLUEBILDSharedConfig.cmake")
+	set(BLUEBILD_TARGETS_FILE "BLUEBILDSharedTargets.cmake")
+endif()
+
+
+# generate cmake package
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+	"${PROJECT_BINARY_DIR}/${BLUEBILD_VERSION_FILE}"
+	VERSION ${Upstream_VERSION}
+	COMPATIBILITY AnyNewerVersion
+)
+export(TARGETS bluebild NAMESPACE BLUEBILD:: FILE ${PROJECT_BINARY_DIR}/${BLUEBILD_TARGETS_FILE})
+configure_file(${PROJECT_SOURCE_DIR}/cmake/${BLUEBILD_CONFIG_FILE}
+	"${PROJECT_BINARY_DIR}/${BLUEBILD_CONFIG_FILE}"
+	@ONLY
+)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/BLUEBILDConfig.cmake
+	"${PROJECT_BINARY_DIR}/BLUEBILDConfig.cmake"
+	COPYONLY
+)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/BLUEBILDConfigVersion.cmake
+	"${PROJECT_BINARY_DIR}/BLUEBILDConfigVersion.cmake"
+	COPYONLY
+)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/BLUEBILDTargets.cmake
+	"${PROJECT_BINARY_DIR}/BLUEBILDTargets.cmake"
+	COPYONLY
+)
+
+# installation commands
+if(BLUEBILD_INSTALL)
+	install(TARGETS bluebild DESTINATION ${CMAKE_INSTALL_LIBDIR} EXPORT BLUEBILDTargets)
+	install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/bluebild DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp" PATTERN "*.f90")
+	install(FILES ${PROJECT_BINARY_DIR}/bluebild/config.h "${PROJECT_BINARY_DIR}/bluebild/bluebild_export.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/bluebild)
+	install(EXPORT BLUEBILDTargets NAMESPACE BLUEBILD:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/BLUEBILD FILE ${BLUEBILD_TARGETS_FILE})
+	install(
+	  FILES
+		"${PROJECT_BINARY_DIR}/BLUEBILDConfig.cmake"
+		"${PROJECT_BINARY_DIR}/BLUEBILDTargets.cmake"
+		"${PROJECT_BINARY_DIR}/BLUEBILDConfigVersion.cmake"
+		"${PROJECT_BINARY_DIR}/${BLUEBILD_CONFIG_FILE}"
+		"${PROJECT_BINARY_DIR}/${BLUEBILD_VERSION_FILE}"
+	  DESTINATION
+	    ${CMAKE_INSTALL_LIBDIR}/cmake/BLUEBILD
+	)
+
+	install(DIRECTORY "${PROJECT_SOURCE_DIR}/cmake/modules"
+		DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/BLUEBILD"
+        FILES_MATCHING PATTERN "*.cmake")
+
+endif()

--- a/src/bluebild/src/context.cpp
+++ b/src/bluebild/src/context.cpp
@@ -1,0 +1,36 @@
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+
+namespace bluebild {
+
+extern "C" {
+BLUEBILD_EXPORT BluebildError bluebild_ctx_create(BluebildProcessingUnit pu, BluebildContext* ctx) {
+  int nEigOut;
+  try {
+    *reinterpret_cast<ContextInternal**>(ctx) = new ContextInternal(pu);
+  } catch (const bluebild::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+
+BLUEBILD_EXPORT BluebildError bluebild_ctx_destroy(BluebildContext* ctx) {
+  if (!ctx || !(*ctx)) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    delete *reinterpret_cast<ContextInternal**>(ctx);
+    *reinterpret_cast<ContextInternal**>(ctx) = nullptr;
+  } catch (const bluebild::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+}
+}  // namespace bluebild

--- a/src/bluebild/src/context_internal.hpp
+++ b/src/bluebild/src/context_internal.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <memory>
+#include <cassert>
+#include <functional>
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "bluebild/exceptions.hpp"
+#include "memory/allocator_collection.hpp"
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+#include <cusolverDn.h>
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "gpu/util/gpu_blas_api.hpp"
+#endif
+
+namespace bluebild {
+
+class ContextInternal {
+  public:
+    explicit ContextInternal(BluebildProcessingUnit pu) {
+      if(pu == BLUEBILD_PU_AUTO) {
+        // select GPU if available
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+        int deviceId = 0;
+        if (gpu::get_device(&deviceId) == gpu::status::Success) {
+          pu_ = BLUEBILD_PU_GPU;
+        } else {
+          pu_ = BLUEBILD_PU_CPU;
+        }
+#else
+        pu_ = BLUEBILD_PU_CPU;
+#endif
+      } else {
+        pu_ = pu;
+      }
+
+      if (pu_ == BLUEBILD_PU_GPU) {
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+        // create stream
+        gpu::StreamType stream;
+        gpu::check_status(gpu::stream_create_with_flags(&stream, gpu::flag::StreamNonBlocking));
+        gpuStream_ = std::unique_ptr<gpu::StreamType, std::function<void(gpu::StreamType*)>>(
+            new gpu::StreamType(stream), [](gpu::StreamType* ptr) {
+              gpu::stream_destroy(*ptr);
+              delete ptr;
+            });
+
+        // create blas handle
+        gpu::blas::HandleType blasHandle;
+        gpu::blas::check_status(gpu::blas::create(&blasHandle));
+        gpuBlasHandle_ =
+            std::unique_ptr<gpu::blas::HandleType, std::function<void(gpu::blas::HandleType*)>>(
+                new gpu::blas::HandleType(blasHandle), [](gpu::blas::HandleType* ptr) {
+                  gpu::blas::destroy(*ptr);
+                  delete ptr;
+                });
+        gpu::blas::set_stream(*gpuBlasHandle_, *gpuStream_);
+
+        // create gpu solver
+        cusolverDnHandle_t solverHandle;
+        if (cusolverDnCreate(&solverHandle) != CUSOLVER_STATUS_SUCCESS) throw GPUError();
+        gpuSolverHandle_ =
+            std::unique_ptr<cusolverDnHandle_t, std::function<void(cusolverDnHandle_t*)>>(
+                new cusolverDnHandle_t(solverHandle), [](cusolverDnHandle_t* ptr) {
+                  cusolverDnDestroy(*ptr);
+                  delete ptr;
+                });
+
+        if (cusolverDnSetStream(solverHandle, *gpuStream_) != CUSOLVER_STATUS_SUCCESS)
+          throw GPUError();
+
+#else
+        throw GPUSupportError();  // CPU not implemented yet
+#endif
+      }
+    }
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+    auto gpu_stream() const -> const gpu::StreamType& {
+      return *gpuStream_;
+    }
+
+    auto gpu_blas_handle() const -> const gpu::blas::HandleType& {
+      return *gpuBlasHandle_;
+    }
+
+    auto gpu_solver_handle() const -> const cusolverDnHandle_t& {
+      return *gpuSolverHandle_;
+    }
+#endif
+
+    auto allocators() -> AllocatorCollection& { return allocators_; }
+
+    auto processing_unit() const -> BluebildProcessingUnit { return pu_; }
+
+  private:
+    BluebildProcessingUnit pu_;
+    AllocatorCollection allocators_;
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+    std::unique_ptr<gpu::StreamType, std::function<void(gpu::StreamType*)>> gpuStream_;
+    std::unique_ptr<gpu::blas::HandleType, std::function<void(gpu::blas::HandleType*)>> gpuBlasHandle_;
+    std::unique_ptr<cusolverDnHandle_t, std::function<void(cusolverDnHandle_t*)>> gpuSolverHandle_;
+#endif
+};
+
+}  // namespace bluebild
+

--- a/src/bluebild/src/eigensolver.cpp
+++ b/src/bluebild/src/eigensolver.cpp
@@ -1,0 +1,151 @@
+#include <complex>
+#include <cstddef>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "host/eigensolver_host.hpp"
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "gpu/util/gpu_util.hpp"
+#include "gpu/eigensolver_gpu.hpp"
+#include "memory/buffer.hpp"
+#endif
+
+namespace bluebild {
+template <typename T>
+auto eigh(ContextInternal& ctx, int m, int nEig, const std::complex<T>* a, int lda,
+              const std::complex<T>* b, int ldb, int* nEigOut, T* d, std::complex<T>* v, int ldv)
+    -> void {
+      if(ctx.processing_unit() == BLUEBILD_PU_GPU) {
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+        // Syncronize with default stream. TODO: replace with event
+        gpu::stream_synchronize(nullptr);
+
+        BufferType<gpu::ComplexType<T>> aBuffer, bBuffer, vBuffer;
+        BufferType<T> dBuffer;
+        auto aDevice = reinterpret_cast<const gpu::ComplexType<T>*>(a);
+        auto bDevice = reinterpret_cast<const gpu::ComplexType<T>*>(b);
+        auto dDevice = d;
+        auto vDevice = reinterpret_cast<gpu::ComplexType<T>*>(v);
+        int ldaDevice = lda;
+        int ldbDevice = ldb;
+        int ldvDevice = ldv;
+
+        // copy input if required
+        if(!is_device_ptr(a)) {
+          aBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), m * m);
+          ldaDevice = m;
+          aDevice = aBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(
+              aBuffer.get(), ldaDevice * sizeof(gpu::ComplexType<T>), a,
+              lda * sizeof(gpu::ComplexType<T>), m * sizeof(gpu::ComplexType<T>), m,
+              gpu::flag::MemcpyHostToDevice, ctx.gpu_stream()));
+        }
+
+        if(b && !is_device_ptr(b)) {
+          bBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), m * m);
+          ldbDevice = m;
+          bDevice = bBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(
+              bBuffer.get(), ldbDevice * sizeof(gpu::ComplexType<T>), b,
+              ldb * sizeof(gpu::ComplexType<T>), m * sizeof(gpu::ComplexType<T>), m,
+              gpu::flag::MemcpyHostToDevice, ctx.gpu_stream()));
+        }
+
+        if(!is_device_ptr(v)) {
+          vBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), nEig * m);
+          ldvDevice = m;
+          vDevice = vBuffer.get();
+        }
+
+        if(!is_device_ptr(d)) {
+          dBuffer = create_buffer<T>(ctx.allocators().gpu(), nEig);
+          dDevice = dBuffer.get();
+        }
+
+        // call eigh on GPU
+        auto devInfo = eigh_gpu<T>(ctx, m, nEig, aDevice, ldaDevice, bDevice, ldbDevice, nEigOut,
+                                   dDevice, vDevice, ldvDevice);
+
+        // copy back results if required
+        if(vBuffer) {
+          gpu::check_status(gpu::memcpy_2d_async(
+              v, ldv * sizeof(gpu::ComplexType<T>), vBuffer.get(),
+              ldvDevice * sizeof(gpu::ComplexType<T>), m * sizeof(gpu::ComplexType<T>), nEig,
+              gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+        }
+        if(dBuffer) {
+          gpu::check_status(gpu::memcpy_async(d, dDevice, nEig * sizeof(T),
+                                              gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+        }
+
+        int hostInfo[2];
+        gpu::check_status(gpu::memcpy_async(hostInfo, devInfo.get(), 2 * sizeof(int),
+                                            gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+
+        // syncronize with stream to be synchronous with host
+        gpu::check_status(gpu::stream_synchronize(ctx.gpu_stream()));
+
+        // check if eigensolver threw error
+        if (hostInfo[0] || hostInfo[1]) {
+          throw EigensolverError();
+        }
+#else
+        throw GPUSupportError();
+#endif
+      } else {
+        eigh_host<T>(ctx, m, nEig, a, lda, b, ldb, nEigOut, d, v, ldv);
+      }
+}
+
+extern "C" {
+BLUEBILD_EXPORT BluebildError bluebild_eigh_s(BluebildContext ctx, int m,
+                                              int nEig, const void *a, int lda,
+                                              const void *b, int ldb,
+                                              int *nEigOut, float *d, void *v,
+                                              int ldv) {
+  if (!ctx) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    eigh<float>(*reinterpret_cast<ContextInternal *>(ctx), m, nEig,
+                reinterpret_cast<const std::complex<float> *>(a), lda,
+                reinterpret_cast<const std::complex<float> *>(b), ldb, nEigOut,
+                d, reinterpret_cast<std::complex<float> *>(v), ldv);
+  } catch (const bluebild::GenericError &e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+
+BLUEBILD_EXPORT BluebildError bluebild_eigh_d(BluebildContext ctx, int m,
+                                              int nEig, const void *a, int lda,
+                                              const void *b, int ldb,
+                                              int *nEigOut, double *d, void *v,
+                                              int ldv) {
+  if (!ctx) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    eigh<double>(*reinterpret_cast<ContextInternal *>(ctx), m, nEig,
+                 reinterpret_cast<const std::complex<double> *>(a), lda,
+                 reinterpret_cast<const std::complex<double> *>(b), ldb,
+                 nEigOut, d, reinterpret_cast<std::complex<double> *>(v), ldv);
+  } catch (const bluebild::GenericError &e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+}
+
+} // namespace bluebild

--- a/src/bluebild/src/eigensolver.hpp
+++ b/src/bluebild/src/eigensolver.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <complex>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+
+namespace bluebild {
+template <typename T>
+auto eigh_gpu(ContextInternal& ctx, int m, int nEig, const std::complex<T>* a, int lda,
+              const std::complex<T>* b, int ldb, int* nEigOut, T* d, std::complex<T>* v, int ldv)
+    -> void;
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/eigensolver_gpu.cpp
+++ b/src/bluebild/src/gpu/eigensolver_gpu.cpp
@@ -1,0 +1,288 @@
+
+#include <cusolverDn.h>
+
+#include <complex>
+#include <cstddef>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "memory/buffer.hpp"
+#include "context_internal.hpp"
+#include "gpu/kernels/reverse.hpp"
+#include "gpu/util/gpu_blas_api.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild {
+
+namespace eigensolver {
+auto worspace_size(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+                   cublasFillMode_t uplo, int n, float* A, int lda, float vl, float vu, int il,
+                   int iu) -> int {
+  int lwork = 0;
+  if (cusolverDnSsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu, nullptr,
+                                   nullptr, &lwork) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+  return lwork;
+}
+auto worspace_size(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+                   cublasFillMode_t uplo, int n, double* A, int lda, double vl, double vu, int il,
+                   int iu) -> int {
+  int lwork = 0;
+  if (cusolverDnDsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu, nullptr,
+                                   nullptr, &lwork) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+  return lwork;
+}
+auto worspace_size(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+                   cublasFillMode_t uplo, int n, cuComplex* A, int lda, float vl, float vu, int il,
+                   int iu) -> int {
+  int lwork = 0;
+  if (cusolverDnCheevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu, nullptr,
+                                   nullptr, &lwork) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+  return lwork;
+}
+auto worspace_size(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+                   cublasFillMode_t uplo, int n, cuDoubleComplex* A, int lda, double vl, double vu,
+                   int il, int iu) -> int {
+  int lwork = 0;
+  if (cusolverDnZheevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu, nullptr,
+                                   nullptr, &lwork) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+  return lwork;
+}
+
+auto solve(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+           cublasFillMode_t uplo, int n, float* A, int lda, float vl, float vu, int il, int iu,
+           int* hMeig, float* W, float* work, int lwork, int* devInfo) -> void {
+  if (cusolverDnSsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu, hMeig, W, work, lwork,
+                        devInfo) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+}
+
+auto solve(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+           cublasFillMode_t uplo, int n, double* A, int lda, double vl, double vu, int il, int iu,
+           int* hMeig, double* W, double* work, int lwork, int* devInfo) -> void {
+  if (cusolverDnDsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu, hMeig, W, work, lwork,
+                        devInfo) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+}
+
+auto solve(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+           cublasFillMode_t uplo, int n, cuComplex* A, int lda, float vl, float vu, int il, int iu,
+           int* hMeig, float* W, cuComplex* work, int lwork, int* devInfo) -> void {
+  if (cusolverDnCheevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu, hMeig, W, work, lwork,
+                        devInfo) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+}
+
+auto solve(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+           cublasFillMode_t uplo, int n, cuDoubleComplex* A, int lda, double vl, double vu, int il,
+           int iu, int* hMeig, double* W, cuDoubleComplex* work, int lwork, int* devInfo) -> void {
+  if (cusolverDnZheevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu, hMeig, W, work, lwork,
+                        devInfo) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+}
+
+}  // namespace eigensolver
+
+namespace general_eigensolver {
+auto worspace_size(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+                   cublasFillMode_t uplo, int n, float* A, int lda, float* B, int ldb, float vl,
+                   float vu, int il, int iu) -> int {
+  int lwork = 0;
+  if (cusolverDnSsygvdx_bufferSize(handle, CUSOLVER_EIG_TYPE_1, jobz, range, uplo, n, A, lda, B,
+                                   ldb, vl, vu, il, iu, nullptr, nullptr,
+                                   &lwork) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+  return lwork;
+}
+auto worspace_size(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+                   cublasFillMode_t uplo, int n, double* A, int lda, double* B, int ldb, double vl,
+                   double vu, int il, int iu) -> int {
+  int lwork = 0;
+  if (cusolverDnDsygvdx_bufferSize(handle, CUSOLVER_EIG_TYPE_1, jobz, range, uplo, n, A, lda, B,
+                                   ldb, vl, vu, il, iu, nullptr, nullptr,
+                                   &lwork) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+  return lwork;
+}
+auto worspace_size(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+                   cublasFillMode_t uplo, int n, cuComplex* A, int lda, cuComplex* B, int ldb,
+                   float vl, float vu, int il, int iu) -> int {
+  int lwork = 0;
+  if (cusolverDnChegvdx_bufferSize(handle, CUSOLVER_EIG_TYPE_1, jobz, range, uplo, n, A, lda, B,
+                                   ldb, vl, vu, il, iu, nullptr, nullptr,
+                                   &lwork) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+  return lwork;
+}
+auto worspace_size(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+                   cublasFillMode_t uplo, int n, cuDoubleComplex* A, int lda, cuDoubleComplex* B,
+                   int ldb, double vl, double vu, int il, int iu) -> int {
+  int lwork = 0;
+  if (cusolverDnZhegvdx_bufferSize(handle, CUSOLVER_EIG_TYPE_1, jobz, range, uplo, n, A, lda, B,
+                                   ldb, vl, vu, il, iu, nullptr, nullptr,
+                                   &lwork) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+  return lwork;
+}
+
+auto solve(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+           cublasFillMode_t uplo, int n, float* A, int lda, float* B, int ldb, float vl, float vu,
+           int il, int iu, int* hMeig, float* W, float* work, int lwork, int* devInfo) -> void {
+  if (cusolverDnSsygvdx(handle, CUSOLVER_EIG_TYPE_1, jobz, range, uplo, n, A, lda, B, ldb, vl, vu,
+                        il, iu, hMeig, W, work, lwork, devInfo) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+}
+
+auto solve(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+           cublasFillMode_t uplo, int n, double* A, int lda, double* B, int ldb, double vl,
+           double vu, int il, int iu, int* hMeig, double* W, double* work, int lwork, int* devInfo)
+    -> void {
+  if (cusolverDnDsygvdx(handle, CUSOLVER_EIG_TYPE_1, jobz, range, uplo, n, A, lda, B, ldb, vl, vu,
+                        il, iu, hMeig, W, work, lwork, devInfo) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+}
+
+auto solve(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+           cublasFillMode_t uplo, int n, cuComplex* A, int lda, cuComplex* B, int ldb, float vl,
+           float vu, int il, int iu, int* hMeig, float* W, cuComplex* work, int lwork, int* devInfo)
+    -> void {
+  if (cusolverDnChegvdx(handle, CUSOLVER_EIG_TYPE_1, jobz, range, uplo, n, A, lda, B, ldb, vl, vu,
+                        il, iu, hMeig, W, work, lwork, devInfo) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+}
+
+auto solve(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+           cublasFillMode_t uplo, int n, cuDoubleComplex* A, int lda, cuDoubleComplex* B, int ldb,
+           double vl, double vu, int il, int iu, int* hMeig, double* W, cuDoubleComplex* work,
+           int lwork, int* devInfo) -> void {
+  if (cusolverDnZhegvdx(handle, CUSOLVER_EIG_TYPE_1, jobz, range, uplo, n, A, lda, B, ldb, vl, vu,
+                        il, iu, hMeig, W, work, lwork, devInfo) != CUSOLVER_STATUS_SUCCESS)
+    throw GPUError();
+}
+
+}  // namespace general_eigensolver
+
+template <typename T>
+auto eigh_gpu(ContextInternal& ctx, int m, int nEig, const gpu::ComplexType<T>* a, int lda,
+              const gpu::ComplexType<T>* b, int ldb, int* nEigOut, T* d, gpu::ComplexType<T>* v,
+              int ldv) -> BufferType<int> {
+  // TODO: add fill mode
+  using ComplexType = gpu::ComplexType<T>;
+  using ScalarType = T;
+
+  auto aBuffer = create_buffer<ComplexType>(ctx.allocators().gpu(), m * m);  // Matrix A
+  auto dBuffer = create_buffer<T>(ctx.allocators().gpu(), m);  // Matrix A
+
+  gpu::check_status(gpu::memcpy_2d_async(aBuffer.get(), m * sizeof(ComplexType), a,
+                                         lda * sizeof(ComplexType), m * sizeof(ComplexType), m,
+                                         gpu::flag::MemcpyDeviceToDevice, ctx.gpu_stream()));
+  int hMeig = 0;
+
+  int lwork = eigensolver::worspace_size(ctx.gpu_solver_handle(), CUSOLVER_EIG_MODE_VECTOR,
+                                         CUSOLVER_EIG_RANGE_V, CUBLAS_FILL_MODE_LOWER, m, aBuffer.get(),
+                                         m, std::numeric_limits<T>::epsilon(),
+                                         std::numeric_limits<T>::max(), 1, m);
+  auto workspace = create_buffer<ComplexType>(ctx.allocators().gpu(), lwork);
+  auto devInfo = create_buffer<int>(ctx.allocators().gpu(), 2);
+  // make sure info is always 0. Second entry might not be set otherwise.
+  gpu::memset_async(devInfo.get(), 0, 2 * sizeof(int), ctx.gpu_stream());
+
+  // compute positive eigenvalues
+  eigensolver::solve(ctx.gpu_solver_handle(), CUSOLVER_EIG_MODE_VECTOR, CUSOLVER_EIG_RANGE_V,
+                     CUBLAS_FILL_MODE_LOWER, m, aBuffer.get(), m, std::numeric_limits<T>::epsilon(),
+                     std::numeric_limits<T>::max(), 1, m, &hMeig, dBuffer.get(), workspace.get(),
+                     lwork, devInfo.get());
+
+  if (b) {
+    auto bBuffer = create_buffer<ComplexType>(ctx.allocators().gpu(), m * m);  // Matrix B
+    gpu::check_status(gpu::memcpy_2d_async(bBuffer.get(), m * sizeof(ComplexType), b,
+                                           ldb * sizeof(ComplexType), m * sizeof(ComplexType), m,
+                                           gpu::flag::MemcpyDeviceToDevice, ctx.gpu_stream()));
+    if (hMeig != m) {
+      // reconstuct 'a' without negative eigenvalues (v * diag(d) * v^H)
+      auto dComplexD = create_buffer<ComplexType>(ctx.allocators().gpu(), m);
+      auto cD = create_buffer<ComplexType>(ctx.allocators().gpu(), m * m);
+      auto newABuffer = create_buffer<ComplexType>(ctx.allocators().gpu(), m * m);
+
+      // copy scalar eigenvalues to complex for multiplication
+      gpu::check_status(
+          gpu::memset_async(dComplexD.get(), 0, hMeig * sizeof(ComplexType), ctx.gpu_stream()));
+      gpu::check_status(gpu::memcpy_2d_async(dComplexD.get(), sizeof(ComplexType), dBuffer.get(),
+                                             sizeof(ScalarType), sizeof(ScalarType), hMeig,
+                                             gpu::flag::MemcpyDeviceToDevice, ctx.gpu_stream()));
+
+      gpu::blas::check_status(gpu::blas::dgmm(ctx.gpu_blas_handle(), gpu::blas::side::right, m,
+                                              hMeig, aBuffer.get(), m, dComplexD.get(), 1, cD.get(), m));
+      ComplexType alpha{1, 0};
+      ComplexType beta{0, 0};
+      gpu::blas::check_status(gpu::blas::gemm(ctx.gpu_blas_handle(), gpu::blas::operation::None,
+                                              gpu::blas::operation::ConjugateTranspose, m, m, hMeig,
+                                              &alpha, cD.get(), m, aBuffer.get(), m, &beta,
+                                              newABuffer.get(), m));
+      std::swap(newABuffer, aBuffer);
+    } else {
+      // a was overwritten by eigensolver
+      gpu::check_status(gpu::memcpy_2d_async(aBuffer.get(), m * sizeof(ComplexType), a,
+                                             lda * sizeof(ComplexType), m * sizeof(ComplexType), m,
+                                             gpu::flag::MemcpyDeviceToDevice, ctx.gpu_stream()));
+    }
+
+    // allocate new work buffer
+    lwork = general_eigensolver::worspace_size(
+        ctx.gpu_solver_handle(), CUSOLVER_EIG_MODE_VECTOR, CUSOLVER_EIG_RANGE_V,
+        CUBLAS_FILL_MODE_LOWER, m, aBuffer.get(), m, bBuffer.get(), m,
+        std::numeric_limits<T>::epsilon(), std::numeric_limits<T>::max(), 1, m);
+    workspace.reset();
+    workspace = create_buffer<ComplexType>(ctx.allocators().gpu(), lwork);
+
+    // compute positive general eigenvalues
+    general_eigensolver::solve(ctx.gpu_solver_handle(), CUSOLVER_EIG_MODE_VECTOR,
+                               CUSOLVER_EIG_RANGE_V, CUBLAS_FILL_MODE_LOWER, m, aBuffer.get(), m,
+                               bBuffer.get(), m, std::numeric_limits<T>::epsilon(),
+                               std::numeric_limits<T>::max(), 1, m, &hMeig, dBuffer.get(),
+                               workspace.get(), lwork, devInfo.get() + 1);
+  }
+
+  if (hMeig > 1) {
+    // reverse order, such that large eigenvalues are first
+    reverse_1_gpu<ScalarType>(ctx.gpu_stream(), hMeig, dBuffer.get());
+    reverse_2_gpu(ctx.gpu_stream(), m, hMeig, aBuffer.get(), m);
+  }
+
+  if (hMeig < nEig) {
+    // fewer positive eigenvalues found than requested. Setting others to 0.
+    gpu::check_status(
+        gpu::memset_async(d + hMeig, 0, (nEig - hMeig) * sizeof(ScalarType), ctx.gpu_stream()));
+    gpu::check_status(gpu::memset_async(
+        aBuffer.get() + hMeig * m, 0, (nEig - hMeig) * m * sizeof(ComplexType), ctx.gpu_stream()));
+  }
+
+  // copy results to output
+  gpu::check_status(gpu::memcpy_async(d, dBuffer.get(), nEig * sizeof(ScalarType),
+                                      gpu::flag::MemcpyDeviceToDevice, ctx.gpu_stream()));
+  gpu::check_status(gpu::memcpy_2d_async(v, ldv * sizeof(ComplexType), aBuffer.get(),
+                                         m * sizeof(ComplexType), m * sizeof(ComplexType), nEig,
+                                         gpu::flag::MemcpyDeviceToDevice, ctx.gpu_stream()));
+
+  *nEigOut = std::min<int>(hMeig, nEig);
+  return devInfo;
+}
+
+template auto eigh_gpu<float>(ContextInternal& ctx, int m, int nEig,
+                              const gpu::ComplexType<float>* a, int lda,
+                              const gpu::ComplexType<float>* b, int ldb, int* nEigOut, float* d,
+                              gpu::ComplexType<float>* v, int ldv) -> BufferType<int>;
+
+template auto eigh_gpu<double>(ContextInternal& ctx, int m, int nEig,
+                               const gpu::ComplexType<double>* a, int lda,
+                               const gpu::ComplexType<double>* b, int ldb, int* nEigOut, double* d,
+                               gpu::ComplexType<double>* v, int ldv) -> BufferType<int>;
+
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/eigensolver_gpu.hpp
+++ b/src/bluebild/src/gpu/eigensolver_gpu.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <complex>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "memory/buffer.hpp"
+
+namespace bluebild {
+template <typename T>
+auto eigh_gpu(ContextInternal& ctx, int m, int nEig, const gpu::ComplexType<T>* a, int lda,
+              const gpu::ComplexType<T>* b, int ldb, int* nEigOut, T* d, gpu::ComplexType<T>* v,
+              int ldv) -> BufferType<int>;
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/gram_matrix_gpu.cpp
+++ b/src/bluebild/src/gpu/gram_matrix_gpu.cpp
@@ -1,0 +1,66 @@
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "memory/buffer.hpp"
+#include "context_internal.hpp"
+#include "gpu/eigensolver_gpu.hpp"
+#include "gpu/kernels/gram.hpp"
+#include "gpu/util/gpu_blas_api.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto gram_matrix_gpu(ContextInternal& ctx, int m, int n, const gpu::ComplexType<T>* w, int ldw,
+                     const T* xyz, int ldxyz, T wl, gpu::ComplexType<T>* g, int ldg) -> void {
+  using ComplexType = gpu::ComplexType<T>;
+
+  // Syncronize with default stream. TODO: replace with event
+  gpu::stream_synchronize(nullptr);
+
+  auto baseD = create_buffer<ComplexType>(ctx.allocators().gpu(), m * m);
+
+  {
+    auto xyzD = create_buffer<T>(ctx.allocators().gpu(), 3 * m);
+    gpu::check_status(gpu::memcpy_2d_async(xyzD.get(), m * sizeof(T), xyz, ldxyz * sizeof(T),
+                                           m * sizeof(T), 3, gpu::flag::MemcpyDefault,
+                                           ctx.gpu_stream()));
+    gram_gpu(ctx.gpu_stream(), m, xyzD.get(), xyzD.get() + m, xyzD.get() + 2 * m, wl, baseD.get(),
+             m);
+  }
+
+  auto wD = create_buffer<ComplexType>(ctx.allocators().gpu(), m * n);
+  auto cD = create_buffer<ComplexType>(ctx.allocators().gpu(), m * n);
+  gpu::check_status(gpu::memcpy_2d_async(wD.get(), m * sizeof(ComplexType), w,
+                                         ldw * sizeof(ComplexType), m * sizeof(ComplexType), n,
+                                         gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+  ComplexType alpha{1, 0};
+  ComplexType beta{0, 0};
+  gpu::blas::check_status(gpu::blas::symm(ctx.gpu_blas_handle(), gpu::blas::side::left,
+                                          gpu::blas::fill::lower, m, n, &alpha, baseD.get(), m,
+                                          wD.get(), m, &beta, cD.get(), m));
+  auto gD = create_buffer<ComplexType>(ctx.allocators().gpu(), n * n);
+  gpu::blas::check_status(gpu::blas::gemm(
+      ctx.gpu_blas_handle(), gpu::blas::operation::ConjugateTranspose, gpu::blas::operation::None,
+      n, n, m, &alpha, wD.get(), m, cD.get(), m, &beta, gD.get(), n));
+
+  gpu::check_status(gpu::memcpy_2d_async(g, ldg * sizeof(ComplexType), gD.get(),
+                                         n * sizeof(ComplexType), n * sizeof(ComplexType), n,
+                                         gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+
+  gpu::check_status(gpu::stream_synchronize(ctx.gpu_stream()));  // syncronize with stream
+}
+
+template auto gram_matrix_gpu<float>(ContextInternal& ctx, int m, int n,
+                                     const gpu::ComplexType<float>* w, int ldw, const float* xyz,
+                                     int ldxyz, float wl, gpu::ComplexType<float>* g, int ldg)
+    -> void;
+
+template auto gram_matrix_gpu<double>(ContextInternal& ctx, int m, int n,
+                                      const gpu::ComplexType<double>* w, int ldw, const double* xyz,
+                                      int ldxyz, double wl, gpu::ComplexType<double>* g, int ldg)
+    -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/gram_matrix_gpu.hpp
+++ b/src/bluebild/src/gpu/gram_matrix_gpu.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <complex>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild {
+template <typename T>
+auto gram_matrix_gpu(ContextInternal& ctx, int m, int n, const gpu::ComplexType<T>* w, int ldw,
+                     const T* xyz, int ldxyz, T wl, gpu::ComplexType<T>* g, int ldg) -> void;
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/intensity_field_data_gpu.cpp
+++ b/src/bluebild/src/gpu/intensity_field_data_gpu.cpp
@@ -1,0 +1,53 @@
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "memory/buffer.hpp"
+#include "context_internal.hpp"
+#include "gpu/eigensolver_gpu.hpp"
+#include "gpu/kernels/min_diff.hpp"
+#include "gpu/util/gpu_blas_api.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "gpu/gram_matrix_gpu.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto intensity_field_data_gpu(ContextInternal& ctx, T wl, int m, int n, int nEig,
+                              const gpu::ComplexType<T>* s, int lds, const gpu::ComplexType<T>* w,
+                              int ldw, const T* xyz, int ldxyz, T* d, gpu::ComplexType<T>* v,
+                              int ldv, int nCluster, const T* cluster, int* clusterIndices)
+    -> BufferType<int> {
+  using ComplexType = gpu::ComplexType<T>;
+  using ScalarType = T;
+
+
+  auto gD = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), n * n);
+
+  gram_matrix_gpu<T>(ctx, m, n, w, ldw, xyz, ldxyz, wl, gD.get(), n);
+
+  int nEigOut = 0;
+  auto devInfo = eigh_gpu<T>(ctx, n, nEig, s, lds, gD.get(), n, &nEigOut, d, v, ldv);
+
+  if (nEigOut) min_diff_1d_gpu(ctx.gpu_stream(), nCluster, cluster, nEigOut, d, clusterIndices);
+  return devInfo;
+}
+
+template auto intensity_field_data_gpu<float>(ContextInternal& ctx, float wl, int m, int n,
+                                              int nEig, const gpu::ComplexType<float>* s, int lds,
+                                              const gpu::ComplexType<float>* w, int ldw,
+                                              const float* xyz, int ldxyz, float* d,
+                                              gpu::ComplexType<float>* v, int ldv, int nCluster,
+                                              const float* cluster, int* clusterIndices)
+    -> BufferType<int>;
+
+template auto intensity_field_data_gpu<double>(ContextInternal& ctx, double wl, int m, int n,
+                                               int nEig, const gpu::ComplexType<double>* s, int lds,
+                                               const gpu::ComplexType<double>* w, int ldw,
+                                               const double* xyz, int ldxyz, double* d,
+                                               gpu::ComplexType<double>* v, int ldv, int nCluster,
+                                               const double* cluster, int* clusterIndices)
+    -> BufferType<int>;
+
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/intensity_field_data_gpu.hpp
+++ b/src/bluebild/src/gpu/intensity_field_data_gpu.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "memory/buffer.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto intensity_field_data_gpu(ContextInternal& ctx, T wl, int m, int n, int nEig,
+                              const gpu::ComplexType<T>* s, int lds, const gpu::ComplexType<T>* w,
+                              int ldw, const T* xyz, int ldxyz, T* d, gpu::ComplexType<T>* v,
+                              int ldv, int nCluster, const T* cluster, int* clusterIndices)
+    -> BufferType<int>;
+
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/kernels/gram.cu
+++ b/src/bluebild/src/gpu/kernels/gram.cu
@@ -1,0 +1,61 @@
+#include <algorithm>
+#include <complex>
+
+#include "bluebild//config.h"
+#include "gpu/kernels/gram.hpp"
+#include "gpu/util/gpu_runtime.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild {
+
+static __device__ __forceinline__ float calc_sqrt(float x) { return sqrtf(x); }
+static __device__ __forceinline__ double calc_sqrt(double x) { return sqrt(x); }
+
+// compute pi * sinc(x) = pi * (sin(a * x) / (pi * x)u
+static __device__ __forceinline__ float calc_pi_sinc(float a, float x) {
+  return x ? sinf(a * x) / x : float(3.14159265358979323846);
+}
+
+static __device__ __forceinline__ double calc_pi_sinc(double a, double x) {
+  return x ? sin(a * x) / x : double(3.14159265358979323846);
+}
+
+template <typename T>
+static __global__ void gram_kernel(int n, const T* __restrict__ x, const T* __restrict__ y,
+                            const T* __restrict__ z, T wl, gpu::ComplexType<T>* g, int ldg) {
+  for (int j = threadIdx.y + blockIdx.y * blockDim.y; j < n; j += gridDim.y * blockDim.y) {
+    T x1 = x[j];
+    T y1 = y[j];
+    T z1 = z[j];
+    for (int i = j + threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+      T diffX = x1 - x[i];
+      T diffY = y1 - y[i];
+      T diffZ = z1 - z[i];
+
+      T norm = calc_sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
+      g[i + j * ldg] = {4 * calc_pi_sinc(wl, norm), 0};
+    }
+  }
+}
+
+template <typename T>
+auto gram_gpu(gpu::StreamType stream, int n, const T* x, const T* y, const T* z, T wl,
+              gpu::ComplexType<T>* g, int ldg) -> void {
+  constexpr int maxBlocks = 65535;
+  constexpr int blockSize = 16;
+
+  dim3 block(blockSize, blockSize, 1);
+  auto numBlocks = std::min<unsigned int>(maxBlocks, (n + block.x - 1) / block.x);
+  dim3 grid(numBlocks, numBlocks, 1);
+  gpu::launch_kernel(gram_kernel<T>, grid, block, 0, stream, n, x, y, z,
+                     T(2 * 3.14159265358979323846 / wl), g, ldg);
+}
+
+template auto gram_gpu<float>(gpu::StreamType stream, int n, const float* x, const float* y,
+                              const float* z, float wl, gpu::ComplexType<float>* g, int ldg)
+    -> void;
+
+template auto gram_gpu<double>(gpu::StreamType stream, int n, const double* x, const double* y,
+                               const double* z, double wl, gpu::ComplexType<double>* g, int ldg)
+    -> void;
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/kernels/gram.hpp
+++ b/src/bluebild/src/gpu/kernels/gram.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <complex>
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild{
+template <typename T>
+auto gram_gpu(gpu::StreamType stream, int n, const T* x, const T* y, const T* z, T wl,
+              gpu::ComplexType<T>* g, int ldg) -> void;
+}
+

--- a/src/bluebild/src/gpu/kernels/inv_square.cu
+++ b/src/bluebild/src/gpu/kernels/inv_square.cu
@@ -1,0 +1,32 @@
+#include <algorithm>
+#include "bluebild//config.h"
+#include "gpu/util/gpu_runtime.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild{
+
+template<typename T>
+__global__ void inv_square_1d_kernel(int n, T* x) {
+  for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+    T val = x[i];
+    x[i] = T(1) / (val * val);
+  }
+}
+
+
+template <typename T>
+auto inv_square_1d_gpu(gpu::StreamType stream, int n, T* x) -> void {
+    constexpr int maxBlocks = 65535;
+    constexpr int blockSize = 256;
+
+    dim3 block(blockSize, 1, 1);
+    dim3 grid(std::min<unsigned int>(maxBlocks, (n + block.x - 1) / block.x), 1, 1);
+    gpu::launch_kernel(inv_square_1d_kernel<T>, grid, block, 0, stream, n, x);
+}
+
+
+template auto inv_square_1d_gpu<float>(gpu::StreamType stream, int n, float* x) -> void;
+
+template auto inv_square_1d_gpu<double>(gpu::StreamType stream, int n, double* x) -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/kernels/inv_square.hpp
+++ b/src/bluebild/src/gpu/kernels/inv_square.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild {
+template <typename T>
+auto inv_square_1d_gpu(gpu::StreamType stream, int n, T* x) -> void;
+}

--- a/src/bluebild/src/gpu/kernels/min_diff.cu
+++ b/src/bluebild/src/gpu/kernels/min_diff.cu
@@ -1,0 +1,60 @@
+#include <algorithm>
+#include "bluebild//config.h"
+#include "gpu/util/gpu_runtime.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild{
+
+template<int BLOCK_SIZE, typename T>
+__global__ void min_diff_1d_kernel(int m, const T* x, int n, const T* y, int* indices) {
+  __shared__ T storage[BLOCK_SIZE];
+  int minIndex = 0;
+  T minValue(0);
+  T yValue(0);
+
+  for (int idxOut = threadIdx.x + blockIdx.x * BLOCK_SIZE; (idxOut / BLOCK_SIZE) * BLOCK_SIZE < n;
+       idxOut += gridDim.x * BLOCK_SIZE) {
+    if (idxOut < n) yValue = y[idxOut];
+
+    for (int i = 0; i < m; i += BLOCK_SIZE) {
+      // load next block of x
+      int idxRead = i + threadIdx.x;
+      if (idxRead < m) {
+        storage[threadIdx.x] = x[idxRead];
+      }
+      __syncthreads();
+
+      // loop over loaded block
+      int size = BLOCK_SIZE > m - i ? m - i : BLOCK_SIZE;
+      for (int j = 0; j < size; ++j) {
+        // compute the absolute difference
+        T diff = storage[j] - yValue;
+        if (diff < 0) diff = -diff;
+
+        // store minimum. Always store if first iteration.
+        if (diff < minValue || !(i + j)) {
+          minValue = diff;
+          minIndex = i + j;
+        }
+      }
+    }
+    if (idxOut < n) indices[idxOut] = minIndex;
+  }
+}
+
+template <typename T>
+auto min_diff_1d_gpu(gpu::StreamType stream, int m, const T* x, int n, const T* y, int* indices)
+    -> void {
+  constexpr int maxBlocks = 65535;
+  constexpr int blockSize = 128;
+
+  dim3 block(blockSize, 1, 1);
+  dim3 grid(std::min<unsigned int>(maxBlocks, (n + block.x - 1) / block.x), 1, 1);
+  gpu::launch_kernel(min_diff_1d_kernel<blockSize, T>, grid, block, 0, stream, m, x, n, y, indices);
+}
+
+template auto min_diff_1d_gpu<float>(gpu::StreamType stream, int m, const float* x, int n, const float* y, int* indices) -> void;
+
+template auto min_diff_1d_gpu<double>(gpu::StreamType stream, int m, const double* x, int n, const double* y, int* indices) -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/kernels/min_diff.hpp
+++ b/src/bluebild/src/gpu/kernels/min_diff.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild {
+template <typename T>
+auto min_diff_1d_gpu(gpu::StreamType stream, int m, const T* x, int n, const T* y, int* indices)
+    -> void;
+}

--- a/src/bluebild/src/gpu/kernels/reverse.cu
+++ b/src/bluebild/src/gpu/kernels/reverse.cu
@@ -1,0 +1,69 @@
+#include <algorithm>
+#include "bluebild//config.h"
+#include "gpu/util/gpu_runtime.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild{
+
+template<typename T>
+__global__ void reverse_1d_kernel(int n, T* x) {
+  for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < n / 2; i += gridDim.x * blockDim.x) {
+    T x1 = x[i];
+    T x2 = x[n - 1 - i];
+    x[n - 1 - i] = x1;
+    x[i] = x2;
+  }
+}
+
+template <typename T>
+__global__ void reverse_2d_coloumns_kernel(int m, int n, T* x, int ld) {
+  for (int i = blockIdx.y; i < n / 2; i += gridDim.y) {
+    for (int j = threadIdx.x + blockIdx.x * blockDim.x; j < m; j += gridDim.x * blockDim.x) {
+      T x1 = x[i * ld + j];
+      T x2 = x[(n - 1 - i) * ld + j];
+      x[(n - 1 - i) * ld + j] = x1;
+      x[i * ld + j] = x2;
+    }
+  }
+}
+
+template <typename T>
+auto reverse_1_gpu(gpu::StreamType stream, int n, T* x) -> void {
+    constexpr int maxBlocks = 65535;
+    constexpr int blockSize = 256;
+
+    dim3 block(blockSize, 1, 1);
+    dim3 grid(std::min<unsigned int>(maxBlocks, (n + block.x - 1) / block.x), 1, 1);
+    gpu::launch_kernel(reverse_1d_kernel<T>, grid, block, 0, stream, n, x);
+}
+
+template <typename T>
+auto reverse_2_gpu(gpu::StreamType stream, int m, int n, T* x, int ld) -> void {
+  constexpr int maxBlocks = 65535;
+  constexpr int blockSize = 256;
+
+  dim3 block{blockSize / 8, 8, 1};
+  dim3 grid{std::min<unsigned int>(maxBlocks, (m + block.x - 1) / block.x),
+            std::min<unsigned int>(maxBlocks, (n + block.y - 1) / block.y), 1};
+  gpu::launch_kernel(reverse_2d_coloumns_kernel<T>, grid, block, 0, stream, m, n, x, ld);
+}
+
+template auto reverse_1_gpu<float>(gpu::StreamType stream, int n, float* x) -> void;
+
+template auto reverse_1_gpu<double>(gpu::StreamType stream, int n, double* x) -> void;
+
+template auto reverse_1_gpu<cuComplex>(gpu::StreamType stream, int n, cuComplex* x) -> void;
+
+template auto reverse_1_gpu<cuDoubleComplex>(gpu::StreamType stream, int n, cuDoubleComplex* x)
+    -> void;
+
+template auto reverse_2_gpu<float>(gpu::StreamType stream, int m, int n, float* x, int ld) -> void;
+
+template auto reverse_2_gpu<double>(gpu::StreamType stream, int m, int n, double* x, int ld) -> void;
+
+template auto reverse_2_gpu<cuComplex>(gpu::StreamType stream, int m, int n, cuComplex* x, int ld) -> void;
+
+template auto reverse_2_gpu<cuDoubleComplex>(gpu::StreamType stream, int m, int n, cuDoubleComplex* x, int ld)
+    -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/kernels/reverse.hpp
+++ b/src/bluebild/src/gpu/kernels/reverse.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild{
+
+template <typename T>
+auto reverse_1_gpu(gpu::StreamType stream, int n, T* x) -> void;
+
+template <typename T>
+auto reverse_2_gpu(gpu::StreamType stream, int m, int n, T* x, int ld) -> void;
+
+}
+

--- a/src/bluebild/src/gpu/sensitivity_field_data_gpu.cpp
+++ b/src/bluebild/src/gpu/sensitivity_field_data_gpu.cpp
@@ -1,0 +1,44 @@
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "gpu/eigensolver_gpu.hpp"
+#include "gpu/gram_matrix_gpu.hpp"
+#include "memory/buffer.hpp"
+#include "gpu/kernels/inv_square.hpp"
+#include "gpu/util/gpu_blas_api.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto sensitivity_field_data_gpu(ContextInternal& ctx, T wl, int m, int n, int nEig,
+                                const gpu::ComplexType<T>* w, int ldw, const T* xyz, int ldxyz,
+                                T* d, gpu::ComplexType<T>* v, int ldv) -> BufferType<int> {
+  using ScalarType = T;
+
+  auto gD = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), n * n);
+
+  gram_matrix_gpu<T>(ctx, m, n, w, ldw, xyz, ldxyz, wl, gD.get(), n);
+
+  int nEigOut = 0;
+  auto devInfo = eigh_gpu<T>(ctx, n, nEig, gD.get(), n, nullptr, 0, &nEigOut, d, v, ldv);
+
+  if (nEigOut) inv_square_1d_gpu(ctx.gpu_stream(), nEigOut, d);
+  return devInfo;
+}
+
+template auto sensitivity_field_data_gpu<float>(ContextInternal& ctx, float wl, int m, int n,
+                                                int nEig, const gpu::ComplexType<float>* w, int ldw,
+                                                const float* xyz, int ldxyz, float* d,
+                                                gpu::ComplexType<float>* v, int ldv)
+    -> BufferType<int>;
+
+template auto sensitivity_field_data_gpu<double>(ContextInternal& ctx, double wl, int m, int n,
+                                                 int nEig, const gpu::ComplexType<double>* w,
+                                                 int ldw, const double* xyz, int ldxyz, double* d,
+                                                 gpu::ComplexType<double>* v, int ldv)
+    -> BufferType<int>;
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/sensitivity_field_data_gpu.hpp
+++ b/src/bluebild/src/gpu/sensitivity_field_data_gpu.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "memory/buffer.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto sensitivity_field_data_gpu(ContextInternal& ctx, T wl, int m, int n, int nEig,
+                                const gpu::ComplexType<T>* w, int ldw, const T* xyz, int ldxyz,
+                                T* d, gpu::ComplexType<T>* v, int ldv) -> BufferType<int>;
+}

--- a/src/bluebild/src/gpu/util/gpu_blas_api.hpp
+++ b/src/bluebild/src/gpu/util/gpu_blas_api.hpp
@@ -1,0 +1,338 @@
+#pragma once
+
+#include <stdexcept>
+#include <utility>
+
+#include "bluebild/config.h"
+
+#if defined(BLUEBILD_CUDA)
+#include <cublas_v2.h>
+
+#elif defined(BLUEBILD_ROCM)
+#include <rocblas.h>
+
+#else
+#error Either BLUEBILD_CUDA or BLUEBILD_ROCM must be defined!
+#endif
+
+#include "bluebild/exceptions.hpp"
+
+namespace bluebild {
+namespace gpu {
+namespace blas {
+
+#if defined(BLUEBILD_CUDA)
+using HandleType = cublasHandle_t;
+using StatusType = cublasStatus_t;
+using OperationType = cublasOperation_t;
+using SideModeType = cublasSideMode_t;
+using FillModeType = cublasFillMode_t;
+using ComplexFloatType = cuComplex;
+using ComplexDoubleType = cuDoubleComplex;
+#endif
+
+#if defined(BLUEBILD_ROCM)
+using HandleType = rocblas_handle;
+using StatusType = rocblas_status;
+using OperationType = rocblas_operation;
+using SideModeType = rocblas_side;
+using FillModeType = rocblas_fill;
+using ComplexFloatType = rocblas_float_complex;
+using ComplexDoubleType = rocblas_double_complex;
+#endif
+
+namespace operation {
+#if defined(BLUEBILD_CUDA)
+constexpr auto None = CUBLAS_OP_N;
+constexpr auto Transpose = CUBLAS_OP_T;
+constexpr auto ConjugateTranspose = CUBLAS_OP_C;
+#endif
+
+#if defined(BLUEBILD_ROCM)
+constexpr auto None = rocblas_operation_none;
+constexpr auto Transpose = rocblas_operation_transpose;
+constexpr auto ConjugateTranspose = rocblas_operation_conjugate_transpose;
+#endif
+}  // namespace operation
+
+namespace side {
+#if defined(BLUEBILD_CUDA)
+constexpr auto left = CUBLAS_SIDE_LEFT;
+constexpr auto right = CUBLAS_SIDE_RIGHT;
+#endif
+
+#if defined(BLUEBILD_ROCM)
+constexpr auto left = rocblas_side_left;
+constexpr auto right = rocblas_side_right;
+#endif
+}  // namespace side
+
+namespace fill {
+#if defined(BLUEBILD_CUDA)
+constexpr auto upper = CUBLAS_FILL_MODE_UPPER;
+constexpr auto lower = CUBLAS_FILL_MODE_LOWER;
+constexpr auto full = CUBLAS_FILL_MODE_FULL;
+#endif
+
+#if defined(BLUEBILD_ROCM)
+constexpr auto upper = rocblas_fill_upper;
+constexpr auto lower = rocblas_fill_lower;
+constexpr auto full = rocblas_fill_full;
+#endif
+}  // namespace side
+
+namespace status {
+#if defined(BLUEBILD_CUDA)
+constexpr auto Success = CUBLAS_STATUS_SUCCESS;
+#endif
+
+#if defined(BLUEBILD_ROCM)
+constexpr auto Success = rocblas_status_success;
+#endif
+
+static const char *get_string(StatusType error) {
+#if defined(BLUEBILD_CUDA)
+  switch (error) {
+    case CUBLAS_STATUS_SUCCESS:
+      return "CUBLAS_STATUS_SUCCESS";
+
+    case CUBLAS_STATUS_NOT_INITIALIZED:
+      return "CUBLAS_STATUS_NOT_INITIALIZED";
+
+    case CUBLAS_STATUS_ALLOC_FAILED:
+      return "CUBLAS_STATUS_ALLOC_FAILED";
+
+    case CUBLAS_STATUS_INVALID_VALUE:
+      return "CUBLAS_STATUS_INVALID_VALUE";
+
+    case CUBLAS_STATUS_ARCH_MISMATCH:
+      return "CUBLAS_STATUS_ARCH_MISMATCH";
+
+    case CUBLAS_STATUS_MAPPING_ERROR:
+      return "CUBLAS_STATUS_MAPPING_ERROR";
+
+    case CUBLAS_STATUS_EXECUTION_FAILED:
+      return "CUBLAS_STATUS_EXECUTION_FAILED";
+
+    case CUBLAS_STATUS_INTERNAL_ERROR:
+      return "CUBLAS_STATUS_INTERNAL_ERROR";
+
+    case CUBLAS_STATUS_NOT_SUPPORTED:
+      return "CUBLAS_STATUS_NOT_SUPPORTED";
+
+    case CUBLAS_STATUS_LICENSE_ERROR:
+      return "CUBLAS_STATUS_LICENSE_ERROR";
+  }
+#endif
+
+#if defined(BLUEBILD_ROCM)
+  switch (error) {
+    case rocblas_status_success:
+      return "rocblas_status_success";
+
+    case rocblas_status_invalid_handle:
+      return "rocblas_status_invalid_handle";
+
+    case rocblas_status_not_implemented:
+      return "rocblas_status_not_implemented";
+
+    case rocblas_status_invalid_pointer:
+      return "rocblas_status_invalid_pointer";
+
+    case rocblas_status_invalid_size:
+      return "rocblas_status_invalid_size";
+
+    case rocblas_status_memory_error:
+      return "rocblas_status_memory_error";
+
+    case rocblas_status_internal_error:
+      return "rocblas_status_internal_error";
+
+    case rocblas_status_perf_degraded:
+      return "rocblas_status_perf_degraded";
+
+    case rocblas_status_size_query_mismatch:
+      return "rocblas_status_size_query_mismatch";
+
+    case rocblas_status_size_increased:
+      return "rocblas_status_size_increased";
+
+    case rocblas_status_size_unchanged:
+      return "rocblas_status_size_unchanged";
+  }
+#endif
+
+  return "<unknown>";
+}
+}  // namespace status
+
+inline auto check_status(StatusType error) -> void {
+  if (error != status::Success) {
+    throw GPUBlasError();
+  }
+}
+
+// =======================================
+// Forwarding functions of to GPU BLAS API
+// =======================================
+template <typename... ARGS>
+inline auto create(ARGS &&...args) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasCreate(std::forward<ARGS>(args)...);
+#else
+  return rocblas_create_handle(std::forward<ARGS>(args)...);
+#endif
+}
+
+template <typename... ARGS>
+inline auto destroy(ARGS &&...args) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasDestroy(std::forward<ARGS>(args)...);
+#else
+  return rocblas_destroy_handle(std::forward<ARGS>(args)...);
+#endif
+}
+
+template <typename... ARGS>
+inline auto set_stream(ARGS &&...args) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasSetStream(std::forward<ARGS>(args)...);
+#else
+  return rocblas_set_stream(std::forward<ARGS>(args)...);
+#endif
+}
+
+template <typename... ARGS>
+inline auto get_stream(ARGS &&...args) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasGetStream(std::forward<ARGS>(args)...);
+#else
+  return rocblas_get_stream(std::forward<ARGS>(args)...);
+#endif
+}
+
+inline auto gemm(HandleType handle, OperationType transa, OperationType transb, int m, int n, int k,
+                 const float *alpha, const float *A, int lda, const float *B, int ldb,
+                 const float *beta, float *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasSgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  return rocblas_sgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto gemm(HandleType handle, OperationType transa, OperationType transb, int m, int n, int k,
+                 const double *alpha, const double *A, int lda, const double *B, int ldb,
+                 const double *beta, double *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasDgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  return rocblas_dgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto gemm(HandleType handle, OperationType transa, OperationType transb, int m, int n, int k,
+                 const ComplexFloatType *alpha, const ComplexFloatType *A, int lda,
+                 const ComplexFloatType *B, int ldb, const ComplexFloatType *beta,
+                 ComplexFloatType *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasCgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  return rocblas_cgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto gemm(HandleType handle, OperationType transa, OperationType transb, int m, int n, int k,
+                 const ComplexDoubleType *alpha, const ComplexDoubleType *A, int lda,
+                 const ComplexDoubleType *B, int ldb, const ComplexDoubleType *beta,
+                 ComplexDoubleType *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasZgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  return rocblas_zgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto dgmm(HandleType handle, SideModeType mode, int m, int n, const float *A, int lda,
+                 const float *x, int incx, float *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasSdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc);
+#else
+  return rocblas_sdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto dgmm(HandleType handle, SideModeType mode, int m, int n, const double *A, int lda,
+                 const double *x, int incx, double *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasDdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc);
+#else
+  return rocblas_ddgmm(handle, mode, m, n, A, lda, x, incx, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto dgmm(HandleType handle, SideModeType mode, int m, int n, const ComplexFloatType *A,
+                 int lda, const ComplexFloatType *x, int incx, ComplexFloatType *C, int ldc)
+    -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasCdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc);
+#else
+  return rocblas_cdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto dgmm(HandleType handle, SideModeType mode, int m, int n, const ComplexDoubleType *A,
+                 int lda, const ComplexDoubleType *x, int incx, ComplexDoubleType *C, int ldc)
+    -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasZdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc);
+#else
+  return rocblas_zdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto symm(HandleType handle, SideModeType side, FillModeType uplo, int m, int n,
+                 const float *alpha, const float *A, int lda, const float *B, int ldb,
+                 const float *beta, float *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasSsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  return rocblas_ssymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto symm(HandleType handle, SideModeType side, FillModeType uplo, int m, int n,
+                 const double *alpha, const double *A, int lda, const double *B, int ldb,
+                 const double *beta, double *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasDsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  return rocblas_dsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto symm(HandleType handle, SideModeType side, FillModeType uplo, int m, int n,
+                 const ComplexFloatType *alpha, const ComplexFloatType *A, int lda,
+                 const ComplexFloatType *B, int ldb, const ComplexFloatType *beta,
+                 ComplexFloatType *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasCsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  return rocblas_csymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+inline auto symm(HandleType handle, SideModeType side, FillModeType uplo, int m, int n,
+                 const ComplexDoubleType *alpha, const ComplexDoubleType *A, int lda,
+                 const ComplexDoubleType *B, int ldb, const ComplexDoubleType *beta,
+                 ComplexDoubleType *C, int ldc) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return cublasZsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  return rocblas_zsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc);
+#endif  // BLUEBILD_CUDA
+}
+
+}  // namespace blas
+}  // namespace gpu
+}  // namespace bluebild

--- a/src/bluebild/src/gpu/util/gpu_runtime.hpp
+++ b/src/bluebild/src/gpu/util/gpu_runtime.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "bluebild/config.h"
+
+#ifdef BLUEBILD_ROCM
+#include <hip/hip_runtime.h>
+#endif
+
+namespace bluebild {
+namespace gpu {
+
+#ifdef BLUEBILD_CUDA
+template <typename F, typename... ARGS>
+inline auto launch_kernel(F func, const dim3 threadGrid, const dim3 threadBlock,
+                          const size_t sharedMemoryBytes, const gpu::StreamType stream,
+                          ARGS&&... args) -> void {
+#ifndef NDEBUG
+  gpu::device_synchronize();
+  gpu::check_status(gpu::get_last_error());  // before
+#endif
+  func<<<threadGrid, threadBlock, sharedMemoryBytes, stream>>>(std::forward<ARGS>(args)...);
+#ifndef NDEBUG
+  gpu::device_synchronize();
+  gpu::check_status(gpu::get_last_error());  // after
+#endif
+}
+#endif
+
+#ifdef BLUEBILD_ROCM
+template <typename F, typename... ARGS>
+inline auto launch_kernel(F func, const dim3 threadGrid, const dim3 threadBlock,
+                          const size_t sharedMemoryBytes, const gpu::StreamType stream,
+                          ARGS&&... args) -> void {
+#ifndef NDEBUG
+  gpu::device_synchronize();
+  gpu::check_status(gpu::get_last_error());  // before
+#endif
+  hipLaunchKernelGGL(func, threadGrid, threadBlock, sharedMemoryBytes, stream,
+                     std::forward<ARGS>(args)...);
+#ifndef NDEBUG
+  gpu::device_synchronize();
+  gpu::check_status(gpu::get_last_error());  // after
+#endif
+}
+#endif
+
+}  // namespace gpu
+}  // namespace bluebild
+

--- a/src/bluebild/src/gpu/util/gpu_runtime_api.hpp
+++ b/src/bluebild/src/gpu/util/gpu_runtime_api.hpp
@@ -1,0 +1,253 @@
+#pragma once
+
+#include "bluebild/config.h"
+
+#if defined(BLUEBILD_CUDA)
+#include <cuda_runtime_api.h>
+#include <cuComplex.h>
+#define GPU_PREFIX(val) cuda##val
+
+#elif defined(BLUEBILD_ROCM)
+#include <hip/hip_runtime_api.h>
+#define GPU_PREFIX(val) hip##val
+#endif
+
+// only declare namespace members if GPU support is enabled
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+
+#include <utility>
+#include <complex>
+
+#include "bluebild/exceptions.hpp"
+
+namespace bluebild {
+namespace gpu {
+
+using StatusType = GPU_PREFIX(Error_t);
+using StreamType = GPU_PREFIX(Stream_t);
+using EventType = GPU_PREFIX(Event_t);
+
+#ifdef BLUEBILD_CUDA
+using PointerAttributes = GPU_PREFIX(PointerAttributes);
+
+using ComplexDoubleType = cuDoubleComplex;
+using ComplexFloatType = cuComplex;
+#else
+using PointerAttributes = GPU_PREFIX(PointerAttribute_t);
+using ComplexDoubleType = hipDoubleComplex;
+using ComplexFloatType = hipComplex;
+#endif
+
+template <typename T>
+using ComplexType = std::conditional_t<std::is_same<T, float>{}, ComplexFloatType,
+                                       std::conditional_t<std::is_same<T, std::complex<float>>{},
+                                                          ComplexFloatType, ComplexDoubleType>>;
+
+namespace status {
+// error / return values
+constexpr StatusType Success = GPU_PREFIX(Success);
+constexpr StatusType ErrorMemoryAllocation = GPU_PREFIX(ErrorMemoryAllocation);
+constexpr StatusType ErrorLaunchOutOfResources = GPU_PREFIX(ErrorLaunchOutOfResources);
+constexpr StatusType ErrorInvalidValue = GPU_PREFIX(ErrorInvalidValue);
+constexpr StatusType ErrorInvalidResourceHandle = GPU_PREFIX(ErrorInvalidResourceHandle);
+constexpr StatusType ErrorInvalidDevice = GPU_PREFIX(ErrorInvalidDevice);
+constexpr StatusType ErrorInvalidMemcpyDirection = GPU_PREFIX(ErrorInvalidMemcpyDirection);
+constexpr StatusType ErrorInvalidDevicePointer = GPU_PREFIX(ErrorInvalidDevicePointer);
+constexpr StatusType ErrorInitializationError = GPU_PREFIX(ErrorInitializationError);
+constexpr StatusType ErrorNoDevice = GPU_PREFIX(ErrorNoDevice);
+constexpr StatusType ErrorNotReady = GPU_PREFIX(ErrorNotReady);
+constexpr StatusType ErrorUnknown = GPU_PREFIX(ErrorUnknown);
+constexpr StatusType ErrorPeerAccessNotEnabled = GPU_PREFIX(ErrorPeerAccessNotEnabled);
+constexpr StatusType ErrorPeerAccessAlreadyEnabled = GPU_PREFIX(ErrorPeerAccessAlreadyEnabled);
+constexpr StatusType ErrorHostMemoryAlreadyRegistered =
+    GPU_PREFIX(ErrorHostMemoryAlreadyRegistered);
+constexpr StatusType ErrorHostMemoryNotRegistered = GPU_PREFIX(ErrorHostMemoryNotRegistered);
+constexpr StatusType ErrorUnsupportedLimit = GPU_PREFIX(ErrorUnsupportedLimit);
+}  // namespace status
+
+// flags to pass to GPU API
+namespace flag {
+constexpr auto HostRegisterDefault = GPU_PREFIX(HostRegisterDefault);
+constexpr auto HostRegisterPortable = GPU_PREFIX(HostRegisterPortable);
+constexpr auto HostRegisterMapped = GPU_PREFIX(HostRegisterMapped);
+constexpr auto HostRegisterIoMemory = GPU_PREFIX(HostRegisterIoMemory);
+
+constexpr auto StreamDefault = GPU_PREFIX(StreamDefault);
+constexpr auto StreamNonBlocking = GPU_PREFIX(StreamNonBlocking);
+
+constexpr auto MemoryTypeHost = GPU_PREFIX(MemoryTypeHost);
+constexpr auto MemoryTypeDevice = GPU_PREFIX(MemoryTypeDevice);
+#if (CUDART_VERSION >= 10000)
+constexpr auto MemoryTypeUnregistered = GPU_PREFIX(MemoryTypeUnregistered);
+constexpr auto MemoryTypeManaged = GPU_PREFIX(MemoryTypeManaged);
+#endif
+
+constexpr auto MemcpyDefault = GPU_PREFIX(MemcpyDefault);
+constexpr auto MemcpyHostToDevice = GPU_PREFIX(MemcpyHostToDevice);
+constexpr auto MemcpyDeviceToHost = GPU_PREFIX(MemcpyDeviceToHost);
+constexpr auto MemcpyDeviceToDevice = GPU_PREFIX(MemcpyDeviceToDevice);
+
+constexpr auto EventDefault = GPU_PREFIX(EventDefault);
+constexpr auto EventBlockingSync = GPU_PREFIX(EventBlockingSync);
+constexpr auto EventDisableTiming = GPU_PREFIX(EventDisableTiming);
+constexpr auto EventInterprocess = GPU_PREFIX(EventInterprocess);
+}  // namespace flag
+
+// ==================================
+// Error check functions
+// ==================================
+inline auto check_status(StatusType error) -> void {
+  if (error != status::Success) {
+    if (error == status::ErrorMemoryAllocation) throw GPUAllocationError();
+    if (error == status::ErrorLaunchOutOfResources) throw GPULaunchError();
+    if (error == status::ErrorNoDevice) throw GPUNoDeviceError();
+    if (error == status::ErrorInvalidValue) throw GPUInvalidValueError();
+    if (error == status::ErrorInvalidDevicePointer) throw GPUInvalidDevicePointerError();
+
+    throw GPUError();
+  }
+}
+
+// ==================================
+// Forwarding functions of to GPU API
+// ==================================
+template <typename... ARGS>
+inline auto host_register(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(HostRegister)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto host_unregister(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(HostUnregister)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto stream_create_with_flags(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(StreamCreateWithFlags)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto stream_destroy(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(StreamDestroy)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto stream_wait_event(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(StreamWaitEvent)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto event_create_with_flags(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(EventCreateWithFlags)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto event_destroy(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(EventDestroy)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto event_record(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(EventRecord)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto event_synchronize(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(EventSynchronize)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto malloc(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(Malloc)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto malloc_host(ARGS&&... args) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return GPU_PREFIX(MallocHost)(std::forward<ARGS>(args)...);
+#else
+  // hip deprecated hipMallocHost in favour of hipHostMalloc
+  return GPU_PREFIX(HostMalloc)(std::forward<ARGS>(args)...);
+#endif
+}
+
+template <typename... ARGS>
+inline auto free(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(Free)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto free_host(ARGS&&... args) -> StatusType {
+#if defined(BLUEBILD_CUDA)
+  return GPU_PREFIX(FreeHost)(std::forward<ARGS>(args)...);
+#else
+  // hip deprecated hipFreeHost in favour of hipHostFree
+  return GPU_PREFIX(HostFree)(std::forward<ARGS>(args)...);
+#endif
+}
+
+template <typename... ARGS>
+inline auto memcpy(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(Memcpy)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto memcpy_2d(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(Memcpy2D)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto memcpy_async(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(MemcpyAsync)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto memcpy_2d_async(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(Memcpy2DAsync)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto get_device(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(GetDevice)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto set_device(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(SetDevice)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto get_device_count(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(GetDeviceCount)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto stream_synchronize(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(StreamSynchronize)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto memset_async(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(MemsetAsync)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto pointer_get_attributes(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(PointerGetAttributes)(std::forward<ARGS>(args)...);
+}
+
+template <typename... ARGS>
+inline auto mem_get_info(ARGS&&... args) -> StatusType {
+  return GPU_PREFIX(MemGetInfo)(std::forward<ARGS>(args)...);
+}
+
+inline auto get_last_error() -> StatusType { return GPU_PREFIX(GetLastError)(); }
+
+inline auto device_synchronize() -> StatusType { return GPU_PREFIX(DeviceSynchronize)(); }
+
+}  // namespace gpu
+}  // namespace bluebild
+
+#undef GPU_PREFIX
+
+#endif  // defined BLUEBILD_CUDA || BLUEBILD_ROCM

--- a/src/bluebild/src/gpu/util/gpu_util.hpp
+++ b/src/bluebild/src/gpu/util/gpu_util.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "bluebild/config.h"
+#include "gpu/util/gpu_runtime_api.hpp"
+
+namespace bluebild {
+template <typename T>
+auto is_device_ptr(const T* ptr) -> bool {
+  gpu::PointerAttributes attr;
+  auto status = gpu::pointer_get_attributes(&attr, static_cast<const void*>(ptr));
+
+  if (status != gpu::status::Success) {
+    // throw error if unexpected error
+    if (status != gpu::status::ErrorInvalidValue) gpu::check_status(status);
+    // clear error from cache and return otherwise
+    gpu::get_last_error();
+    return false;
+  }
+
+  // get memory type - cuda 10 changed attribute name
+#if defined(BLUEBILD_CUDA) && (CUDART_VERSION >= 10000)
+  auto memoryType = attr.type;
+#else
+  auto memoryType = attr.memoryType;
+#endif
+
+  if (memoryType == gpu::flag::MemoryTypeDevice) {
+    return true;
+  }
+  return false;
+}
+}  // namespace bluebild

--- a/src/bluebild/src/gram_matrix.cpp
+++ b/src/bluebild/src/gram_matrix.cpp
@@ -1,0 +1,122 @@
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "memory/buffer.hpp"
+#include "context_internal.hpp"
+#include "host/gram_matrix_host.hpp"
+
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+#include "memory/buffer.hpp"
+#include "eigensolver.hpp"
+#include "gpu/gram_matrix_gpu.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "gpu/util/gpu_util.hpp"
+#endif
+
+namespace bluebild {
+
+template <typename T>
+auto gram_matrix(ContextInternal& ctx, int m, int n, const std::complex<T>* w, int ldw, const T* xyz,
+                     int ldxyz, T wl, std::complex<T>* g, int ldg) -> void {
+      if(ctx.processing_unit() == BLUEBILD_PU_GPU) {
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+        // Syncronize with default stream. TODO: replace with event
+        gpu::stream_synchronize(nullptr);
+
+        BufferType<gpu::ComplexType<T>> wBuffer, gBuffer;
+        BufferType<T> xyzBuffer;
+        auto wDevice = reinterpret_cast<const gpu::ComplexType<T>*>(w);
+        auto gDevice = reinterpret_cast<gpu::ComplexType<T>*>(g);
+        auto xyzDevice = xyz;
+        int ldwDevice = ldw;
+        int ldgDevice = ldg;
+        int ldxyzDevice = ldxyz;
+
+
+        // copy input if required
+        if(!is_device_ptr(w)) {
+          wBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), m * n);
+          ldwDevice = m;
+          wDevice = wBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(
+              wBuffer.get(), m * sizeof(gpu::ComplexType<T>), w, ldw * sizeof(gpu::ComplexType<T>),
+              m * sizeof(gpu::ComplexType<T>), n, gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+        }
+
+        if(!is_device_ptr(xyz)) {
+          xyzBuffer = create_buffer<T>(ctx.allocators().gpu(), 3 * m);
+          ldxyzDevice = m;
+          xyzDevice = xyzBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(xyzBuffer.get(), m * sizeof(T), xyz,
+                                                 ldxyz * sizeof(T), m * sizeof(T), 3,
+                                                 gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+        }
+        if(!is_device_ptr(g)) {
+          gBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), n * n);
+          ldgDevice = n;
+          gDevice = gBuffer.get();
+        }
+
+        // call gram on gpu
+        gram_matrix_gpu<T>(ctx, m, n, wDevice, ldwDevice, xyzDevice, ldxyzDevice, wl, gDevice,
+                           ldgDevice);
+
+        // copy back results if required
+        if(gBuffer) {
+          gpu::check_status(gpu::memcpy_2d_async(
+              g, ldg * sizeof(gpu::ComplexType<T>), gBuffer.get(), n * sizeof(gpu::ComplexType<T>),
+              n * sizeof(gpu::ComplexType<T>), n, gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+        }
+
+        // syncronize with stream to be synchronous with host
+        gpu::check_status(gpu::stream_synchronize(ctx.gpu_stream())); 
+#else
+        throw GPUSupportError();
+#endif
+      } else {
+        gram_matrix_host<T>(ctx, m, n, w, ldw, xyz, ldxyz, wl, g, ldg);
+      }
+}
+
+extern "C" {
+BLUEBILD_EXPORT BluebildError bluebild_gram_matrix_s(BluebildContext ctx, int m, int n,
+                                                     const void* w, int ldw, const float* xyz,
+                                                     int ldxyz, float wl, void* g, int ldg) {
+  if (!ctx) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    gram_matrix<float>(*reinterpret_cast<ContextInternal*>(ctx), m, n,
+                       reinterpret_cast<const std::complex<float>*>(w), ldw, xyz, ldxyz, wl,
+                       reinterpret_cast<std::complex<float>*>(g), ldg);
+  } catch (const bluebild::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+
+BLUEBILD_EXPORT BluebildError bluebild_gram_matrix_d(BluebildContext ctx, int m, int n,
+                                                     const void* w, int ldw, const double* xyz,
+                                                     int ldxyz, double wl, void* g, int ldg) {
+  if (!ctx) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    gram_matrix<double>(*reinterpret_cast<ContextInternal*>(ctx), m, n,
+                        reinterpret_cast<const std::complex<double>*>(w), ldw, xyz, ldxyz, wl,
+                        reinterpret_cast<std::complex<double>*>(g), ldg);
+  } catch (const bluebild::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+}
+
+}  // namespace bluebild

--- a/src/bluebild/src/gram_matrix.hpp
+++ b/src/bluebild/src/gram_matrix.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <complex>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+
+namespace bluebild {
+template <typename T>
+auto gram_matrix_gpu(ContextInternal& ctx, int m, int n, const std::complex<T>* w, int ldw,
+                     const T* xyz, int ldxyz, T wl, std::complex<T>* g, int ldg) -> void;
+}  // namespace bluebild

--- a/src/bluebild/src/host/blas_api.hpp
+++ b/src/bluebild/src/host/blas_api.hpp
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <complex>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+extern "C" {
+
+typedef enum CBLAS_LAYOUT { CblasRowMajor = 101, CblasColMajor = 102 } CBLAS_LAYOUT;
+typedef enum CBLAS_TRANSPOSE {
+  CblasNoTrans = 111,
+  CblasTrans = 112,
+  CblasConjTrans = 113
+} CBLAS_TRANSPOSE;
+typedef enum CBLAS_UPLO { CblasUpper = 121, CblasLower = 122 } CBLAS_UPLO;
+typedef enum CBLAS_DIAG { CblasNonUnit = 131, CblasUnit = 132 } CBLAS_DIAG;
+typedef enum CBLAS_SIDE { CblasLeft = 141, CblasRight = 142 } CBLAS_SIDE;
+
+#ifdef BLUEBILD_BLAS_C
+void cblas_sgemm(enum CBLAS_LAYOUT order, enum CBLAS_TRANSPOSE transA, enum CBLAS_TRANSPOSE transB,
+                 int M, int N, int K, float alpha, const float *A, int lda, const float *B, int ldb,
+                 float beta, float *C, int ldc);
+
+void cblas_dgemm(enum CBLAS_LAYOUT order, enum CBLAS_TRANSPOSE transA, enum CBLAS_TRANSPOSE transB,
+                 int M, int N, int K, double alpha, const double *A, int lda, const double *B,
+                 int ldb, double beta, double *C, int ldc);
+
+void cblas_cgemm(enum CBLAS_LAYOUT order, enum CBLAS_TRANSPOSE transA, enum CBLAS_TRANSPOSE transB,
+                 int M, int N, int K, const void *alpha, const void *A, int lda, const void *B,
+                 int ldb, const void *beta, void *C, int ldc);
+
+void cblas_zgemm(enum CBLAS_LAYOUT order, enum CBLAS_TRANSPOSE transA, enum CBLAS_TRANSPOSE transB,
+                 int M, int N, int K, const void *alpha, const void *A, int lda, const void *B,
+                 int ldb, const void *beta, void *C, int ldc);
+
+void cblas_ssymm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side, const CBLAS_UPLO Uplo,
+                 const int M, const int N, const float alpha, const float *A, const int lda,
+                 const float *B, const int ldb, const float beta, float *C, const int ldc);
+
+void cblas_dsymm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side, const CBLAS_UPLO Uplo,
+                 const int M, const int N, const double alpha, const double *A, const int lda,
+                 const double *B, const int ldb, const double beta, double *C, const int ldc);
+
+void cblas_csymm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side, const CBLAS_UPLO Uplo,
+                 const int M, const int N, const void *alpha, const void *A, const int lda,
+                 const void *B, const int ldb, const void *beta, void *C, const int ldc);
+
+void cblas_zsymm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side, const CBLAS_UPLO Uplo,
+                 const int M, const int N, const void *alpha, const void *A, const int lda,
+                 const void *B, const int ldb, const void *beta, void *C, const int ldc);
+#else
+
+
+void sgemm_(const char *TRANSA, const char *TRANSB, const int *M, const int *N,
+            const int *K, const void *ALPHA, const void *A, const int *LDA,
+            const void *B, const int *LDB, const void *BETA, void *C,
+            const int *LDC, int TRANSA_len, int TRANSB_len);
+
+void dgemm_(const char *TRANSA, const char *TRANSB, const int *M, const int *N,
+            const int *K, const void *ALPHA, const void *A, const int *LDA,
+            const void *B, const int *LDB, const void *BETA, void *C,
+            const int *LDC, int TRANSA_len, int TRANSB_len);
+
+void cgemm_(const char *TRANSA, const char *TRANSB, const int *M, const int *N,
+            const int *K, const void *ALPHA, const void *A, const int *LDA,
+            const void *B, const int *LDB, const void *BETA, void *C,
+            const int *LDC, int TRANSA_len, int TRANSB_len);
+
+void zgemm_(const char *TRANSA, const char *TRANSB, const int *M, const int *N,
+            const int *K, const void *ALPHA, const void *A, const int *LDA,
+            const void *B, const int *LDB, const void *BETA, void *C,
+            const int *LDC, int TRANSA_len, int TRANSB_len);
+
+void ssymm_(const char *SIDE, const char *UPLO, const int *M, const int *N,
+            const void *ALPHA, const void *A, const int *LDA, const void *B,
+            const int *LDB, const void *BETA, void *C, const int *LDC,
+            int SIDE_len, int UPLO_len);
+
+void dsymm_(const char *SIDE, const char *UPLO, const int *M, const int *N,
+            const void *ALPHA, const void *A, const int *LDA, const void *B,
+            const int *LDB, const void *BETA, void *C, const int *LDC,
+            int SIDE_len, int UPLO_len);
+
+void csymm_(const char *SIDE, const char *UPLO, const int *M, const int *N,
+            const void *ALPHA, const void *A, const int *LDA, const void *B,
+            const int *LDB, const void *BETA, void *C, const int *LDC,
+            int SIDE_len, int UPLO_len);
+
+void zsymm_(const char *SIDE, const char *UPLO, const int *M, const int *N,
+            const void *ALPHA, const void *A, const int *LDA, const void *B,
+            const int *LDB, const void *BETA, void *C, const int *LDC,
+            int SIDE_len, int UPLO_len);
+
+#endif
+}
+
+namespace bluebild {
+namespace blas {
+
+inline auto cblas_transpose_to_string(CBLAS_TRANSPOSE op) -> const char * {
+  if (op == CblasTrans)
+    return "T";
+  if (op == CblasConjTrans)
+    return "C";
+  return "N";
+}
+
+inline auto cblas_uplo_to_string(CBLAS_UPLO uplo) -> const char * {
+  if (uplo == CblasUpper)
+    return "U";
+  return "L";
+}
+
+inline auto cblas_diag_to_string(CBLAS_DIAG diag) -> const char * {
+  if (diag == CblasNonUnit)
+    return "N";
+  return "U";
+}
+
+inline auto cblas_side_to_string(CBLAS_SIDE side) -> const char * {
+  if (side == CblasLeft)
+    return "L";
+  return "R";
+}
+
+inline auto gemm(CBLAS_LAYOUT order, CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB, int M, int N,
+                 int K, float alpha, const float *A, int lda, const float *B, int ldb, float beta,
+                 float *C, int ldc) -> void {
+#ifdef BLUEBILD_BLAS_C
+  cblas_sgemm(order, transA, transB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  sgemm_(cblas_transpose_to_string(transA), cblas_transpose_to_string(transB),
+         &M, &N, &K, &alpha, A, &lda, B, &ldb, &beta, C, &ldc, 1, 1);
+#endif
+}
+
+inline auto gemm(CBLAS_LAYOUT order, CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB, int M, int N,
+                 int K, double alpha, const double *A, int lda, const double *B, int ldb, double beta,
+                 double *C, int ldc) -> void {
+#ifdef BLUEBILD_BLAS_C
+  cblas_dgemm(order, transA, transB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  dgemm_(cblas_transpose_to_string(transA), cblas_transpose_to_string(transB),
+         &M, &N, &K, &alpha, A, &lda, B, &ldb, &beta, C, &ldc, 1, 1);
+#endif
+}
+
+inline auto gemm(CBLAS_LAYOUT order, CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB, int M, int N,
+                 int K, std::complex<float> alpha, const std::complex<float> *A, int lda,
+                 const std::complex<float> *B, int ldb, std::complex<float> beta,
+                 std::complex<float> *C, int ldc) -> void {
+#ifdef BLUEBILD_BLAS_C
+  cblas_cgemm(order, transA, transB, M, N, K, &alpha, A, lda, B, ldb, &beta, C, ldc);
+#else
+  cgemm_(cblas_transpose_to_string(transA), cblas_transpose_to_string(transB),
+         &M, &N, &K, &alpha, A, &lda, B, &ldb, &beta, C, &ldc, 1, 1);
+#endif
+}
+
+inline auto gemm(CBLAS_LAYOUT order, CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB, int M, int N,
+                 int K, std::complex<double> alpha, const std::complex<double> *A, int lda,
+                 const std::complex<double> *B, int ldb, std::complex<double> beta,
+                 std::complex<double> *C, int ldc) -> void {
+#ifdef BLUEBILD_BLAS_C
+  cblas_zgemm(order, transA, transB, M, N, K, &alpha, A, lda, B, ldb, &beta, C, ldc);
+#else
+  zgemm_(cblas_transpose_to_string(transA), cblas_transpose_to_string(transB),
+         &M, &N, &K, &alpha, A, &lda, B, &ldb, &beta, C, &ldc, 1, 1);
+#endif
+}
+
+inline auto symm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side, const CBLAS_UPLO Uplo,
+                 const int M, const int N, const float alpha, const float *A, const int lda,
+                 const float *B, const int ldb, const float beta, float *C, const int ldc) -> void {
+#ifdef BLUEBILD_BLAS_C
+  cblas_ssymm(layout, Side, Uplo, M, N, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  ssymm_(cblas_side_to_string(Side), cblas_uplo_to_string(Uplo), &M, &N, &alpha,
+         A, &lda, B, &ldb, &beta, C, &ldc, 1, 1);
+#endif
+}
+
+inline auto symm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side, const CBLAS_UPLO Uplo,
+                 const int M, const int N, const double alpha, const double *A, const int lda,
+                 const double *B, const int ldb, const double beta, double *C, const int ldc) -> void {
+#ifdef BLUEBILD_BLAS_C
+  cblas_dsymm(layout, Side, Uplo, M, N, alpha, A, lda, B, ldb, beta, C, ldc);
+#else
+  dsymm_(cblas_side_to_string(Side), cblas_uplo_to_string(Uplo), &M, &N, &alpha,
+         A, &lda, B, &ldb, &beta, C, &ldc, 1, 1);
+#endif
+}
+
+inline auto symm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side, const CBLAS_UPLO Uplo,
+                 const int M, const int N, const std::complex<float> alpha,
+                 const std::complex<float> *A, const int lda, const std::complex<float> *B,
+                 const int ldb, const std::complex<float> beta, std::complex<float> *C,
+                 const int ldc) -> void {
+#ifdef BLUEBILD_BLAS_C
+  cblas_csymm(layout, Side, Uplo, M, N, &alpha, A, lda, B, ldb, &beta, C, ldc);
+#else
+  csymm_(cblas_side_to_string(Side), cblas_uplo_to_string(Uplo), &M, &N, &alpha,
+         A, &lda, B, &ldb, &beta, C, &ldc, 1, 1);
+#endif
+}
+
+inline auto symm(const CBLAS_LAYOUT layout, const CBLAS_SIDE Side, const CBLAS_UPLO Uplo,
+                 const int M, const int N, const std::complex<double> alpha,
+                 const std::complex<double> *A, const int lda, const std::complex<double> *B,
+                 const int ldb, const std::complex<double> beta, std::complex<double> *C,
+                 const int ldc) -> void {
+#ifdef BLUEBILD_BLAS_C
+  cblas_zsymm(layout, Side, Uplo, M, N, &alpha, A, lda, B, ldb, &beta, C, ldc);
+#else
+  zsymm_(cblas_side_to_string(Side), cblas_uplo_to_string(Uplo), &M, &N, &alpha,
+         A, &lda, B, &ldb, &beta, C, &ldc, 1, 1);
+#endif
+}
+
+} // namespace blas
+}  // namespace bluebild

--- a/src/bluebild/src/host/eigensolver_host.cpp
+++ b/src/bluebild/src/host/eigensolver_host.cpp
@@ -1,0 +1,110 @@
+#include "host/eigensolver_host.hpp"
+
+#include <algorithm>
+#include <complex>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "host/blas_api.hpp"
+#include "host/lapack_api.hpp"
+#include "memory/allocator.hpp"
+#include "memory/buffer.hpp"
+
+namespace bluebild {
+template <typename T>
+static auto copy_2d(std::size_t m, std::size_t n, const T* a, std::size_t lda, T* b,
+                    std::size_t ldb) {
+  if(lda == ldb && lda == m) {
+    std::memcpy(b, a, m * n * sizeof(T));
+  } else {
+    for(std::size_t i = 0; i < n; ++i) {
+      std::memcpy(b + i * ldb, a + i * lda, m * sizeof(T));
+    }
+  }
+}
+
+template <typename T>
+auto eigh_host(ContextInternal& ctx, std::size_t m, std::size_t nEig, const std::complex<T>* a,
+               std::size_t lda, const std::complex<T>* b, std::size_t ldb, int* nEigOut, T* d,
+               std::complex<T>* v, std::size_t ldv) -> void {
+  // copy input into buffer since eigensolver will overwrite
+  auto bufferA = create_buffer<std::complex<T>>(ctx.allocators().host(), m * m);
+  copy_2d(m, m, a, lda, bufferA.get(), m);
+
+  auto bufferV = create_buffer<std::complex<T>>(ctx.allocators().host(), m * m);
+  auto bufferD = create_buffer<T>(ctx.allocators().host(), m);
+  auto bufferIfail = create_buffer<int>(ctx.allocators().host(), m);
+
+  auto bufferPtrD = bufferD.get();
+  auto bufferPtrV = bufferV.get();
+
+  int hMeig = 0;
+  if (lapack::eigh_solve(LapackeLayout::COL_MAJOR, 'V', 'V', 'L', m, bufferA.get(), m,
+                         std::numeric_limits<T>::epsilon(), std::numeric_limits<T>::max(), 0, m - 1,
+                         &hMeig, bufferD.get(), bufferV.get(), m, bufferIfail.get())) {
+    throw EigensolverError();
+  }
+
+  if(b) {
+    if(hMeig != m) {
+      // reconstruct A from positive eigenvalues only
+
+      auto bufferC = create_buffer<std::complex<T>>(ctx.allocators().host(), hMeig * m);
+      auto bufferPtrC = bufferC.get();
+
+      // Compute C=V * diag(D)
+      for (std::size_t i = 0; i < static_cast<std::size_t>(hMeig); ++i) {
+        auto a = bufferPtrD[i];
+        for (std::size_t j = 0; j < m; ++j) {
+          bufferPtrC[i * m + j] = a * bufferPtrV[i * m + j];
+        }
+      }
+
+      // Compute C = V * V^H
+      blas::gemm(CblasColMajor, CblasNoTrans, CblasConjTrans, m, m, hMeig, std::complex<T>(1, 0),
+                 bufferPtrC, m, bufferPtrC, m, std::complex<T>{0, 0}, bufferA.get(), m);
+
+    } else {
+      copy_2d(m, m, a, lda, bufferA.get(), m);
+    }
+    // copy input into buffer since eigensolver will overwrite
+    auto bufferB = create_buffer<std::complex<T>>(ctx.allocators().host(), m * m);
+    copy_2d(m, m, b, ldb, bufferB.get(), m);
+
+    if (lapack::eigh_solve(LapackeLayout::COL_MAJOR, 1, 'V', 'V', 'L', m, bufferA.get(), m,
+                           bufferB.get(), m, std::numeric_limits<T>::epsilon(),
+                           std::numeric_limits<T>::max(), 0, m - 1, &hMeig, bufferD.get(),
+                           bufferV.get(), m, bufferIfail.get())) {
+      throw EigensolverError();
+    }
+  }
+
+  // reorder into descending order. At most nEig eigenvalues / eigenvectors.
+  for(std::size_t i = 0; i < std::min<std::size_t>(hMeig, nEig); ++i) {
+    d[i] = bufferPtrD[hMeig - i - 1];
+    std::memcpy(v + i * ldv, bufferPtrV + (hMeig - i - 1) * m, m * sizeof(std::complex<T>));
+  }
+  for(std::size_t i = hMeig; i < nEig; ++i) {
+    d[i] = 0;
+    std::memset(v + i * ldv, 0, m * sizeof(std::complex<T>));
+  }
+
+  *nEigOut = std::min<int>(hMeig, nEig);
+}
+
+template auto eigh_host<float>(ContextInternal& ctx, std::size_t m, std::size_t nEig,
+                               const std::complex<float>* a, std::size_t lda,
+                               const std::complex<float>* b, std::size_t ldb, int* nEigOut,
+                               float* d, std::complex<float>* v, std::size_t ldv) -> void;
+
+template auto eigh_host<double>(ContextInternal& ctx, std::size_t m, std::size_t nEig,
+                                const std::complex<double>* a, std::size_t lda,
+                                const std::complex<double>* b, std::size_t ldb, int* nEigOut,
+                                double* d, std::complex<double>* v, std::size_t ldv) -> void;
+}  // namespace bluebild

--- a/src/bluebild/src/host/eigensolver_host.hpp
+++ b/src/bluebild/src/host/eigensolver_host.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto eigh_host(ContextInternal& ctx, std::size_t m, std::size_t nEig, const std::complex<T>* a,
+               std::size_t lda, const std::complex<T>* b, std::size_t ldb, int* nEigOut, T* d,
+               std::complex<T>* v, std::size_t ldv) -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/host/gram_matrix_host.cpp
+++ b/src/bluebild/src/host/gram_matrix_host.cpp
@@ -1,0 +1,66 @@
+#include "host/gram_matrix_host.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "host/blas_api.hpp"
+#include "memory/allocator.hpp"
+#include "memory/buffer.hpp"
+
+namespace bluebild {
+
+template <typename T>
+static T calc_pi_sinc(T a, T x) {
+  return x ? std::sin(a * x) / x : T(3.14159265358979323846);
+}
+
+template <typename T>
+auto gram_matrix_host(ContextInternal& ctx, std::size_t m, std::size_t n, const std::complex<T>* w,
+                      std::size_t ldw, const T* xyz, std::size_t ldxyz, T wl, std::complex<T>* g,
+                      std::size_t ldg) -> void {
+  auto bufferBase = create_buffer<std::complex<T>>(ctx.allocators().host(), m * m);
+  auto basePtr = bufferBase.get();
+
+  auto x = xyz;
+  auto y = xyz + ldxyz;
+  auto z = xyz + 2 * ldxyz;
+  T sincScale = 2 * 3.14159265358979323846 / wl;
+  for(std::size_t i = 0; i < m;++i) {
+    basePtr[i * m + i] = 4 * 3.14159265358979323846;
+    for (std::size_t j = i + 1; j < m; ++j) {
+      auto diffX = x[i] - x[j];
+      auto diffY = y[i] - y[j];
+      auto diffZ = z[i] - z[j];
+      auto norm = std::sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
+      basePtr[i * m + j] = 4 * calc_pi_sinc(sincScale, norm);
+    }
+  }
+
+  auto bufferC = create_buffer<std::complex<T>>(ctx.allocators().host(), m * n);
+
+  blas::symm(CblasColMajor, CblasLeft, CblasLower, m, n, {1, 0}, basePtr, m, w, ldw, {0, 0},
+             bufferC.get(), m);
+  blas::gemm(CblasColMajor, CblasConjTrans, CblasNoTrans, n, n, m, {1, 0}, w, ldw, bufferC.get(), m,
+             {0, 0}, g, ldg);
+}
+
+template auto gram_matrix_host<float>(ContextInternal& ctx, std::size_t m, std::size_t n,
+                                      const std::complex<float>* w, std::size_t ldw,
+                                      const float* xyz, std::size_t ldxyz, float wl,
+                                      std::complex<float>* g, std::size_t ldg) -> void;
+
+template auto gram_matrix_host<double>(ContextInternal& ctx, std::size_t m, std::size_t n,
+                                       const std::complex<double>* w, std::size_t ldw,
+                                       const double* xyz, std::size_t ldxyz, double wl,
+                                       std::complex<double>* g, std::size_t ldg) -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/host/gram_matrix_host.hpp
+++ b/src/bluebild/src/host/gram_matrix_host.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto gram_matrix_host(ContextInternal& ctx, std::size_t m, std::size_t n, const std::complex<T>* w,
+                      std::size_t ldw, const T* xyz, std::size_t ldxyz, T wl, std::complex<T>* g,
+                      std::size_t ldg) -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/host/intensity_field_data_host.cpp
+++ b/src/bluebild/src/host/intensity_field_data_host.cpp
@@ -1,0 +1,63 @@
+#include "host/intensity_field_data_host.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <limits>
+#include <memory>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "host/blas_api.hpp"
+#include "host/eigensolver_host.hpp"
+#include "host/gram_matrix_host.hpp"
+#include "memory/allocator.hpp"
+#include "memory/buffer.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto intensity_field_data_host(ContextInternal& ctx, T wl, std::size_t m, std::size_t n,
+                               std::size_t nEig, const std::complex<T>* s, std::size_t lds,
+                               const std::complex<T>* w, std::size_t ldw, const T* xyz,
+                               std::size_t ldxyz, T* d, std::complex<T>* v, std::size_t ldv,
+                               std::size_t nCluster, const T* cluster, int* clusterIndices)
+    -> void {
+  auto bufferG = create_buffer<std::complex<T>>(ctx.allocators().host(), n * n);
+
+  gram_matrix_host<T>(ctx, m, n, w, ldw, xyz, ldxyz, wl, bufferG.get(), n);
+
+  int nEigOut = 0;
+  eigh_host<T>(ctx, n, nEig, s, lds, bufferG.get(), n, &nEigOut, d, v, ldv);
+
+  if (nEigOut) {
+    for (std::size_t i = 0; i < static_cast<std::size_t>(nEigOut); ++i) {
+      T min = std::numeric_limits<T>::max();
+      int idx = 0;
+      for (std::size_t j = 0; j < nCluster; ++j) {
+        auto diff = std::abs(cluster[j] - d[i]);
+        if(diff < min) {
+          min = diff;
+          idx = static_cast<int>(j);
+        }
+      }
+      clusterIndices[i] = idx;
+    }
+  }
+}
+
+template auto intensity_field_data_host<float>(
+    ContextInternal& ctx, float wl, std::size_t m, std::size_t n, std::size_t nEig,
+    const std::complex<float>* s, std::size_t lds, const std::complex<float>* w, std::size_t ldw,
+    const float* xyz, std::size_t ldxyz, float* d, std::complex<float>* v, std::size_t ldv,
+    std::size_t nCluster, const float* cluster, int* clusterIndices) -> void;
+
+template auto intensity_field_data_host<double>(
+    ContextInternal& ctx, double wl, std::size_t m, std::size_t n, std::size_t nEig,
+    const std::complex<double>* s, std::size_t lds, const std::complex<double>* w, std::size_t ldw,
+    const double* xyz, std::size_t ldxyz, double* d, std::complex<double>* v, std::size_t ldv,
+    std::size_t nCluster, const double* cluster, int* clusterIndices) -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/host/intensity_field_data_host.hpp
+++ b/src/bluebild/src/host/intensity_field_data_host.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto intensity_field_data_host(ContextInternal& ctx, T wl, std::size_t m, std::size_t n,
+                               std::size_t nEig, const std::complex<T>* s, std::size_t lds,
+                               const std::complex<T>* w, std::size_t ldw, const T* xyz,
+                               std::size_t ldxyz, T* d, std::complex<T>* v, std::size_t ldv,
+                               std::size_t nCluster, const T* cluster, int* clusterIndices) -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/host/lapack_api.hpp
+++ b/src/bluebild/src/host/lapack_api.hpp
@@ -1,0 +1,204 @@
+#pragma once
+
+#include <complex>
+#include <vector>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+extern "C" {
+
+enum class LapackeLayout { ROW_MAJOR = 101, COL_MAJOR = 102 };
+
+#ifdef BLUEBILD_LAPACK_C
+float LAPACKE_slamch(char cmach);
+double LAPACKE_dlamch(char cmach);
+
+int LAPACKE_cheevx(int matrix_layout, char jobz, char range, char uplo, int n,
+                   void *a, int lda, float vl, float vu, int il, int iu,
+                   float abstol, int *m, float *w, void *z, int ldz,
+                   int *ifail);
+int LAPACKE_zheevx(int matrix_layout, char jobz, char range, char uplo, int n,
+                   void *a, int lda, double vl, double vu, int il, int iu,
+                   double abstol, int *m, double *w, void *z, int ldz,
+                   int *ifail);
+int LAPACKE_chegvx(int matrix_layout, int itype, char jobz, char range,
+                   char uplo, int n, void *a, int lda, void *b, int ldb,
+                   float vl, float vu, int il, int iu, float abstol, int *m,
+                   float *w, void *z, int ldz, int *ifail);
+int LAPACKE_zhegvx(int matrix_layout, int itype, char jobz, char range,
+                   char uplo, int n, void *a, int lda, void *b, int ldb,
+                   double vl, double vu, int il, int iu, double abstol, int *m,
+                   double *w, void *z, int ldz, int *ifail);
+#else
+float slamch_(const char *cmach, int cmach_len);
+
+double dlamch_(const char *cmach, int cmach_len);
+
+void cheevx_(const char *JOBZ, const char *RANGE, const char *UPLO,
+             const int *N, void *A, const int *LDA, const void *VL,
+             const void *VU, const int *IL, const int *IU, const void *ABSTOL,
+             const int *M, void *W, void *Z, const int *LDZ, void *WORK,
+             int *LWORK, void *RWORK, int *IWORK, int *IFAIL, int *INFO,
+             int JOBZ_len, int RANGE_len, int UPLO_len);
+
+void zheevx_(const char *JOBZ, const char *RANGE, const char *UPLO,
+             const int *N, void *A, const int *LDA, const void *VL,
+             const void *VU, const int *IL, const int *IU, const void *ABSTOL,
+             const int *M, void *W, void *Z, const int *LDZ, void *WORK,
+             int *LWORK, void *RWORK, int *IWORK, int *IFAIL, int *INFO,
+             int JOBZ_len, int RANGE_len, int UPLO_len);
+
+void chegvx_(const int *ITYPE, const char *JOBZ, const char *RANGE,
+             const char *UPLO, const int *N, void *A, const int *LDA, void *B,
+             const int *LDB, const void *VL, const void *VU, const int *IL,
+             const int *IU, const void *ABSTOL, const int *M, void *W, void *Z,
+             const int *LDZ, void *WORK, int *LWORK, void *RWORK, int *IWORK,
+             int *IFAIL, int *INFO, int JOBZ_len, int RANGE_len, int UPLO_len);
+
+void zhegvx_(const int *ITYPE, const char *JOBZ, const char *RANGE,
+             const char *UPLO, const int *N, void *A, const int *LDA, void *B,
+             const int *LDB, const void *VL, const void *VU, const int *IL,
+             const int *IU, const void *ABSTOL, const int *M, void *W, void *Z,
+             const int *LDZ, void *WORK, int *LWORK, void *RWORK, int *IWORK,
+             int *IFAIL, int *INFO, int JOBZ_len, int RANGE_len, int UPLO_len);
+
+#endif
+}
+
+namespace bluebild {
+namespace lapack {
+static auto eigh_solve(LapackeLayout matrixLayout, char jobz, char range,
+                       char uplo, int n, std::complex<float> *a, int lda,
+                       float vl, float vu, int il, int iu, int *m, float *w,
+                       std::complex<float> *z, int ldz, int *ifail) -> int {
+#ifdef BLUEBILD_LAPACK_C
+  return LAPACKE_cheevx(static_cast<int>(matrixLayout), jobz, range, uplo, n, a,
+                        lda, vl, vu, il, iu, 2 * LAPACKE_slamch('S'), m, w, z,
+                        ldz, ifail);
+#else
+  int info = 0;
+  float abstol = 2 * slamch_("S", 1);
+  int lwork = -1;
+  std::vector<float> rwork(7 * n);
+  std::vector<int> iwork(5 * n);
+  std::complex<float> worksize = 0;
+
+  // get work buffer size
+  cheevx_(&jobz, &range, &uplo, &n, a, &lda, &vl, &vu, &il, &iu, &abstol, m, w,
+          z, &ldz, &worksize, &lwork, rwork.data(), iwork.data(), ifail, &info,
+          1, 1, 1);
+  lwork = static_cast<int>(worksize.real());
+  if (lwork < 2 * n)
+    lwork = 2 * n;
+
+  std::vector<std::complex<float>> work(lwork);
+  cheevx_(&jobz, &range, &uplo, &n, a, &lda, &vl, &vu, &il, &iu, &abstol, m, w,
+          z, &ldz, work.data(), &lwork, rwork.data(), iwork.data(), ifail,
+          &info, 1, 1, 1);
+
+  return info;
+#endif
+}
+
+static auto eigh_solve(LapackeLayout matrixLayout, char jobz, char range,
+                       char uplo, int n, std::complex<double> *a, int lda,
+                       double vl, double vu, int il, int iu, int *m, double *w,
+                       std::complex<double> *z, int ldz, int *ifail) -> int {
+#ifdef BLUEBILD_LAPACK_C
+  return LAPACKE_zheevx(static_cast<int>(matrixLayout), jobz, range, uplo, n, a,
+                        lda, vl, vu, il, iu, 2 * LAPACKE_dlamch('S'), m, w, z,
+                        ldz, ifail);
+#else
+  int info = 0;
+  double abstol = 2 * dlamch_("S", 1);
+  int lwork = -1;
+  std::vector<double> rwork(7 * n);
+  std::vector<int> iwork(5 * n);
+  std::complex<double> worksize = 0;
+
+  // get work buffer size
+  zheevx_(&jobz, &range, &uplo, &n, a, &lda, &vl, &vu, &il, &iu, &abstol, m, w,
+          z, &ldz, &worksize, &lwork, rwork.data(), iwork.data(), ifail, &info,
+          1, 1, 1);
+  lwork = static_cast<int>(worksize.real());
+  if (lwork < 2 * n)
+    lwork = 2 * n;
+
+  std::vector<std::complex<double>> work(lwork);
+  zheevx_(&jobz, &range, &uplo, &n, a, &lda, &vl, &vu, &il, &iu, &abstol, m, w,
+          z, &ldz, work.data(), &lwork, rwork.data(), iwork.data(), ifail,
+          &info, 1, 1, 1);
+
+  return info;
+#endif
+}
+
+static auto eigh_solve(LapackeLayout matrixLayout, int itype, char jobz,
+                       char range, char uplo, int n, std::complex<float> *a,
+                       int lda, std::complex<float> *b, int ldb, float vl,
+                       float vu, int il, int iu, int *m, float *w,
+                       std::complex<float> *z, int ldz, int *ifail) -> int {
+#ifdef BLUEBILD_LAPACK_C
+  return LAPACKE_chegvx(static_cast<int>(matrixLayout), itype, jobz, range,
+                        uplo, n, a, lda, b, ldb, vl, vu, il, iu,
+                        2 * LAPACKE_slamch('S'), m, w, z, ldz, ifail);
+#else
+  int info = 0;
+  float abstol = 2 * slamch_("S", 1);
+  int lwork = -1;
+  std::vector<float> rwork(7 * n);
+  std::vector<int> iwork(5 * n);
+  std::complex<float> worksize = 0;
+
+  // get work buffer size
+  chegvx_(&itype, &jobz, &range, &uplo, &n, a, &lda, b, &ldb, &vl, &vu, &il,
+          &iu, &abstol, m, w, z, &ldz, &worksize, &lwork, rwork.data(),
+          iwork.data(), ifail, &info, 1, 1, 1);
+  lwork = static_cast<int>(worksize.real());
+  if (lwork < 2 * n)
+    lwork = 2 * n;
+
+  std::vector<std::complex<float>> work(lwork);
+  chegvx_(&itype, &jobz, &range, &uplo, &n, a, &lda, b, &ldb, &vl, &vu, &il,
+          &iu, &abstol, m, w, z, &ldz, work.data(), &lwork, rwork.data(),
+          iwork.data(), ifail, &info, 1, 1, 1);
+
+  return info;
+#endif
+}
+
+static auto eigh_solve(LapackeLayout matrixLayout, int itype, char jobz,
+                       char range, char uplo, int n, std::complex<double> *a,
+                       int lda, std::complex<double> *b, int ldb, double vl,
+                       double vu, int il, int iu, int *m, double *w,
+                       std::complex<double> *z, int ldz, int *ifail) -> int {
+#ifdef BLUEBILD_LAPACK_C
+  return LAPACKE_zhegvx(static_cast<int>(matrixLayout), itype, jobz, range,
+                        uplo, n, a, lda, b, ldb, vl, vu, il, iu,
+                        2 * LAPACKE_dlamch('S'), m, w, z, ldz, ifail);
+#else
+  int info = 0;
+  double abstol = 2 * dlamch_("S", 1);
+  int lwork = -1;
+  std::vector<double> rwork(7 * n);
+  std::vector<int> iwork(5 * n);
+  std::complex<double> worksize = 0;
+
+  // get work buffer size
+  zhegvx_(&itype, &jobz, &range, &uplo, &n, a, &lda, b, &ldb, &vl, &vu, &il,
+          &iu, &abstol, m, w, z, &ldz, &worksize, &lwork, rwork.data(),
+          iwork.data(), ifail, &info, 1, 1, 1);
+  lwork = static_cast<int>(worksize.real());
+  if (lwork < 2 * n)
+    lwork = 2 * n;
+
+  std::vector<std::complex<double>> work(lwork);
+  zhegvx_(&itype, &jobz, &range, &uplo, &n, a, &lda, b, &ldb, &vl, &vu, &il,
+          &iu, &abstol, m, w, z, &ldz, work.data(), &lwork, rwork.data(),
+          iwork.data(), ifail, &info, 1, 1, 1);
+
+  return info;
+#endif
+}
+} // namespace lapack
+} // namespace bluebild

--- a/src/bluebild/src/host/sensitivity_field_data_host.cpp
+++ b/src/bluebild/src/host/sensitivity_field_data_host.cpp
@@ -1,0 +1,54 @@
+#include "host/sensitivity_field_data_host.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <utility>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "host/blas_api.hpp"
+#include "host/eigensolver_host.hpp"
+#include "host/gram_matrix_host.hpp"
+#include "memory/allocator.hpp"
+#include "memory/buffer.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto sensitivity_field_data_host(ContextInternal& ctx, T wl, std::size_t m, std::size_t n,
+                                 std::size_t nEig, const std::complex<T>* w, std::size_t ldw,
+                                 const T* xyz, std::size_t ldxyz, T* d, std::complex<T>* v,
+                                 std::size_t ldv) -> void {
+
+  auto bufferG = create_buffer<std::complex<T>>(ctx.allocators().host(), n * n);
+
+  gram_matrix_host<T>(ctx, m, n, w, ldw, xyz, ldxyz, wl, bufferG.get(), n);
+
+  int nEigOut = 0;
+  eigh_host<T>(ctx, n, nEig, bufferG.get(), n, nullptr, 0, &nEigOut, d, v, ldv);
+
+  if (nEigOut) {
+    for (std::size_t i = 0; i < static_cast<std::size_t>(nEigOut); ++i) {
+      d[i] = 1 / (d[i] * d[i]);
+    }
+  }
+}
+
+template auto sensitivity_field_data_host<float>(ContextInternal& ctx, float wl, std::size_t m,
+                                                 std::size_t n, std::size_t nEig,
+                                                 const std::complex<float>* w, std::size_t ldw,
+                                                 const float* xyz, std::size_t ldxyz, float* d,
+                                                 std::complex<float>* v, std::size_t ldv) -> void;
+
+template auto sensitivity_field_data_host<double>(ContextInternal& ctx, double wl, std::size_t m,
+                                                  std::size_t n, std::size_t nEig,
+                                                  const std::complex<double>* w, std::size_t ldw,
+                                                  const double* xyz, std::size_t ldxyz, double* d,
+                                                  std::complex<double>* v, std::size_t ldv) -> void;
+}  // namespace bluebild

--- a/src/bluebild/src/host/sensitivity_field_data_host.hpp
+++ b/src/bluebild/src/host/sensitivity_field_data_host.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+
+namespace bluebild {
+
+template <typename T>
+auto sensitivity_field_data_host(ContextInternal& ctx, T wl, std::size_t m, std::size_t n,
+                                 std::size_t nEig, const std::complex<T>* w, std::size_t ldw,
+                                 const T* xyz, std::size_t ldxyz, T* d, std::complex<T>* v,
+                                 std::size_t ldv) -> void;
+
+}  // namespace bluebild

--- a/src/bluebild/src/intensitiy_field_data.cpp
+++ b/src/bluebild/src/intensitiy_field_data.cpp
@@ -1,0 +1,181 @@
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "memory/buffer.hpp"
+#include "context_internal.hpp"
+#include "host/intensity_field_data_host.hpp"
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+#include "gpu/intensity_field_data_gpu.hpp"
+#include "gpu/util/gpu_blas_api.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "gpu/util/gpu_util.hpp"
+#endif
+
+namespace bluebild {
+
+template <typename T>
+auto intensity_field_data(ContextInternal& ctx, T wl, int m, int n, int nEig,
+                              const std::complex<T>* s, int lds, const std::complex<T>* w, int ldw,
+                              const T* xyz, int ldxyz, T* d, std::complex<T>* v, int ldv,
+                              int nCluster, const T* cluster, int* clusterIndices) -> void {
+      if(ctx.processing_unit() == BLUEBILD_PU_GPU) {
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+        // Syncronize with default stream. TODO: replace with event
+        gpu::stream_synchronize(nullptr);
+
+        BufferType<gpu::ComplexType<T>> sBuffer, wBuffer, vBuffer;
+        BufferType<T> dBuffer, xyzBuffer, clusterBuffer;
+        BufferType<int> clusterIndicesBuffer;
+        auto wDevice = reinterpret_cast<const gpu::ComplexType<T>*>(w);
+        auto sDevice = reinterpret_cast<const gpu::ComplexType<T>*>(s);
+        auto vDevice = reinterpret_cast<gpu::ComplexType<T>*>(v);
+        auto xyzDevice = xyz;
+        auto dDevice = d;
+        auto clusterDevice = cluster;
+        auto clusterIndicesDevice = clusterIndices;
+        int ldwDevice = ldw;
+        int ldsDevice = lds;
+        int ldvDevice = ldv;
+        int ldxyzDevice = ldxyz;
+
+
+        // copy input if required
+        if(!is_device_ptr(w)) {
+          wBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), m * n);
+          ldwDevice = m;
+          wDevice = wBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(
+              wBuffer.get(), m * sizeof(gpu::ComplexType<T>), w, ldw * sizeof(gpu::ComplexType<T>),
+              m * sizeof(gpu::ComplexType<T>), n, gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+        }
+        if(!is_device_ptr(s)) {
+          sBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), n * n);
+          ldsDevice = n;
+          sDevice = sBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(
+              sBuffer.get(), n * sizeof(gpu::ComplexType<T>), s, lds * sizeof(gpu::ComplexType<T>),
+              n * sizeof(gpu::ComplexType<T>), n, gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+        }
+
+        if(!is_device_ptr(xyz)) {
+          xyzBuffer = create_buffer<T>(ctx.allocators().gpu(), 3 * m);
+          ldxyzDevice = m;
+          xyzDevice = xyzBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(xyzBuffer.get(), m * sizeof(T), xyz,
+                                                 ldxyz * sizeof(T), m * sizeof(T), 3,
+                                                 gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+        }
+        if(!is_device_ptr(cluster)) {
+          clusterBuffer = create_buffer<T>(ctx.allocators().gpu(), nCluster);
+          clusterDevice = clusterBuffer.get();
+          gpu::check_status(gpu::memcpy_async(clusterBuffer.get(), cluster, nCluster * sizeof(T),
+                                              gpu::flag::MemcpyHostToDevice, ctx.gpu_stream()));
+        }
+
+
+        // prepare output
+        if(!is_device_ptr(v)) {
+          vBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), nEig * n);
+          ldvDevice = n;
+          vDevice = vBuffer.get();
+        }
+        if(!is_device_ptr(d)) {
+          dBuffer = create_buffer<T>(ctx.allocators().gpu(), nEig);
+          dDevice = dBuffer.get();
+        }
+
+        if(!is_device_ptr(clusterIndices)) {
+          clusterIndicesBuffer = create_buffer<int>(ctx.allocators().gpu(), nEig);
+          clusterIndicesDevice = clusterIndicesBuffer.get();
+        }
+
+
+        // call intensity_field_data on gpu
+        auto devInfo = intensity_field_data_gpu<T>(
+            ctx, wl, m, n, nEig, sDevice, ldsDevice, wDevice, ldwDevice, xyzDevice, ldxyzDevice,
+            dDevice, vDevice, ldvDevice, nCluster, clusterDevice, clusterIndicesDevice);
+
+        // copy back if required
+        if(dBuffer) {
+          gpu::check_status(gpu::memcpy_async(d, dDevice, nEig * sizeof(T),
+                                              gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+        }
+        if(vBuffer) {
+          gpu::check_status(gpu::memcpy_2d_async(
+              v, ldv * sizeof(gpu::ComplexType<T>), vBuffer.get(),
+              ldvDevice * sizeof(gpu::ComplexType<T>), n * sizeof(gpu::ComplexType<T>), nEig,
+              gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+        }
+        if(clusterIndicesBuffer) {
+          gpu::check_status(gpu::memcpy_async(clusterIndices, clusterIndicesBuffer.get(),
+                                              nEig * sizeof(int), gpu::flag::MemcpyDefault,
+                                              ctx.gpu_stream()));
+        }
+
+        int hostInfo[2];
+        gpu::check_status(gpu::memcpy_async(hostInfo, devInfo.get(), 2 * sizeof(int),
+                                            gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+        // syncronize with stream to be synchronous with host
+        gpu::check_status(gpu::stream_synchronize(ctx.gpu_stream()));
+
+        // check if eigensolver threw error
+        if (hostInfo[0] || hostInfo[1]) {
+          throw EigensolverError();
+        }
+#else
+        throw GPUSupportError();
+#endif
+      } else {
+        intensity_field_data_host<T>(ctx, wl, m, n, nEig, s, lds, w, ldw, xyz, ldxyz, d, v, ldv,
+                                     nCluster, cluster, clusterIndices);
+      }
+
+}
+
+extern "C" {
+BLUEBILD_EXPORT BluebildError bluebild_intensity_field_data_s(
+    BluebildContext ctx, float wl, int m, int n, int nEig, const void* s, int lds, const void* w,
+    int ldw, const float* xyz, int ldxyz, float* d, void* v, int ldv, int nCluster,
+    const float* cluster, int* clusterIndices) {
+  if (!ctx) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    intensity_field_data<float>(*reinterpret_cast<ContextInternal*>(ctx), wl, m, n, nEig,
+                                reinterpret_cast<const std::complex<float>*>(s), lds,
+                                reinterpret_cast<const std::complex<float>*>(w), ldw, xyz, ldxyz, d,
+                                reinterpret_cast<std::complex<float>*>(v), ldv, nCluster, cluster,
+                                clusterIndices);
+  } catch (const bluebild::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+
+BLUEBILD_EXPORT BluebildError bluebild_intensity_field_data_d(
+    BluebildContext ctx, double wl, int m, int n, int nEig, const void* s, int lds, const void* w,
+    int ldw, const double* xyz, int ldxyz, double* d, void* v, int ldv, int nCluster,
+    const double* cluster, int* clusterIndices) {
+  if (!ctx) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    intensity_field_data<double>(*reinterpret_cast<ContextInternal*>(ctx), wl, m, n, nEig,
+                                 reinterpret_cast<const std::complex<double>*>(s), lds,
+                                 reinterpret_cast<const std::complex<double>*>(w), ldw, xyz, ldxyz,
+                                 d, reinterpret_cast<std::complex<double>*>(v), ldv, nCluster,
+                                 cluster, clusterIndices);
+  } catch (const bluebild::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+}
+}  // namespace bluebild

--- a/src/bluebild/src/memory/allocator.hpp
+++ b/src/bluebild/src/memory/allocator.hpp
@@ -1,0 +1,31 @@
+#pragma once 
+
+#include <cstddef>
+
+#include "bluebild/config.h"
+#include "bluebild/exceptions.hpp"
+
+namespace bluebild {
+
+class Allocator {
+public:
+  Allocator() = default;
+
+  Allocator(const Allocator&) = delete;
+
+  Allocator(Allocator&&) = default;
+
+  auto operator=(const Allocator&) -> Allocator& = delete;
+
+  auto operator=(Allocator&&) -> Allocator& = default;
+
+  virtual ~Allocator() = default;
+
+  virtual auto allocate(std::size_t size) -> void* = 0;
+
+  virtual auto deallocate(void* ptr) -> void = 0;
+
+  virtual auto size() -> std::uint_least64_t = 0;
+};
+}  // namespace bluebild
+

--- a/src/bluebild/src/memory/allocator_collection.hpp
+++ b/src/bluebild/src/memory/allocator_collection.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+
+#include "memory/allocator.hpp"
+#include "memory/pool_allocator.hpp"
+#include "bluebild/config.h"
+#include "bluebild/exceptions.hpp"
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+#include "gpu/util/gpu_runtime_api.hpp"
+#endif
+
+namespace bluebild {
+class AllocatorCollection {
+public:
+  AllocatorCollection()
+      : allocHost_(new PoolAllocator(std::malloc, std::free))
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+        ,
+        allocPinned_(new PoolAllocator(
+            [](std::size_t size) -> void* {
+              void* ptr = nullptr;
+              gpu::check_status(gpu::malloc_host(&ptr, size));
+              return ptr;
+            },
+            [](void* ptr) -> void { gpu::free_host(ptr); })),
+        allocGPU_(new PoolAllocator(
+            [](std::size_t size) -> void* {
+              void* ptr = nullptr;
+              gpu::check_status(gpu::malloc(&ptr, size));
+              return ptr;
+            },
+            [](void* ptr) -> void { gpu::free(ptr); }))
+#endif
+  {
+
+    allocHost_.reset(new PoolAllocator(std::malloc, std::free));
+  }
+
+  auto host() const -> const std::shared_ptr<Allocator>& { return allocHost_; }
+
+  auto set_host(std::shared_ptr<Allocator> allocator) -> void {
+    assert(allocator);
+    allocHost_ = std::move(allocator);
+  }
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+  auto pinned() const -> const std::shared_ptr<Allocator>& { return allocPinned_; }
+
+  auto set_pinned(std::shared_ptr<Allocator> allocator) -> void {
+    assert(allocator);
+    allocPinned_ = std::move(allocator);
+  }
+
+  auto gpu() const -> const std::shared_ptr<Allocator>& { return allocGPU_; }
+
+  auto set_gpu(std::shared_ptr<Allocator> allocator) -> void {
+    assert(allocator);
+    allocGPU_ = std::move(allocator);
+  }
+#endif
+
+private:
+    std::shared_ptr<Allocator> allocHost_;
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+    std::shared_ptr<Allocator> allocPinned_;
+    std::shared_ptr<Allocator> allocGPU_;
+#endif
+
+};
+}  // namespace bluebild

--- a/src/bluebild/src/memory/buffer.hpp
+++ b/src/bluebild/src/memory/buffer.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <functional>
+#include "bluebild/config.h"
+
+#include "memory/allocator.hpp"
+
+namespace bluebild {
+
+template <typename T>
+using BufferType = std::unique_ptr<T, std::function<void(T*)>>;
+
+// Create buffer by allocing memory through an allocator
+template <typename T>
+auto create_buffer(const std::shared_ptr<Allocator>& alloc, std::size_t size) -> BufferType<T> {
+  return {static_cast<T*>(size ? alloc->allocate(size * sizeof(T)) : nullptr), [=](T* ptr) {
+            if (ptr) alloc->deallocate(ptr);
+          }};
+}
+
+}  // namespace bluebild

--- a/src/bluebild/src/memory/pool_allocator.hpp
+++ b/src/bluebild/src/memory/pool_allocator.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <functional>
+#include <mutex>
+
+#include "bluebild/config.h"
+#include "memory/allocator.hpp"
+#include "bluebild/exceptions.hpp"
+
+namespace bluebild {
+
+class PoolAllocator : public Allocator {
+public:
+  PoolAllocator(std::function<void*(std::size_t)> allocateFunc,
+                std::function<void(void*)> deallocateFunc)
+      : allocateFunc_(std::move(allocateFunc)),
+        deallocateFunc_(std::move(deallocateFunc)),
+        lock_(new std::mutex()), memorySize_(0) {
+    if (!allocateFunc_ || !deallocateFunc_) {
+      throw InvalidAllocatorFunctionError();
+    }
+  }
+
+  PoolAllocator(const PoolAllocator&) = delete;
+
+  PoolAllocator(PoolAllocator&&) = default;
+
+  auto operator=(const PoolAllocator&) -> PoolAllocator& = delete;
+
+  auto operator=(PoolAllocator&&) -> PoolAllocator& = default;
+
+  ~PoolAllocator() override {
+    for (auto& pair : allocatedMem_) {
+      assert(false);  // No allocated memory should still exist with correct usage
+      deallocateFunc_(pair.first);
+      memorySize_ -= pair.second;
+    }
+    for (auto& pair : freeMem_) {
+      deallocateFunc_(pair.second);
+      memorySize_ -= pair.first;
+    }
+  }
+
+  auto allocate(std::size_t size) -> void* override {
+    if (!size) return nullptr;
+    std::lock_guard<std::mutex> guard(*lock_);
+
+    void* ptr = nullptr;
+    // find block which is greater or equal to size
+    auto boundIt = freeMem_.lower_bound(size);
+
+    if (boundIt == freeMem_.end()) {
+      // No memory block is large enough. Free the largest one and allocate new size.
+      if(!freeMem_.empty()) {
+        auto backIt = --freeMem_.end();
+        deallocateFunc_(backIt->second);
+        memorySize_ -= backIt->first;
+        freeMem_.erase(backIt);
+      }
+      ptr = allocateFunc_(size);
+      memorySize_ += size;
+      allocatedMem_.emplace(ptr, size);
+    } else {
+      // Use already allocated memory block.
+      ptr = boundIt->second;
+      allocatedMem_.emplace(boundIt->second, boundIt->first);
+      freeMem_.erase(boundIt);
+    }
+
+    return ptr;
+  }
+
+  auto deallocate(void* ptr) -> void override {
+    std::lock_guard<std::mutex> guard(*lock_);
+
+    auto it = allocatedMem_.find(ptr);
+    assert(it != allocatedMem_.end());  // avoid throwing exception when deallocating
+    if (it != allocatedMem_.end()) {
+      freeMem_.emplace(it->second, it->first);
+      allocatedMem_.erase(it);
+    }
+  }
+
+  auto size() -> std::uint_least64_t override {
+    return memorySize_;
+  }
+
+private:
+  std::function<void*(std::size_t)> allocateFunc_;
+  std::function<void(void*)> deallocateFunc_;
+
+  std::multimap<std::size_t, void*> freeMem_;
+  std::unordered_map<void*, std::size_t> allocatedMem_;
+
+  std::unique_ptr<std::mutex> lock_;
+  std::uint_least64_t memorySize_;
+};
+}  // namespace bluebild

--- a/src/bluebild/src/sensitivity_field_data.cpp
+++ b/src/bluebild/src/sensitivity_field_data.cpp
@@ -1,0 +1,147 @@
+#include <complex>
+#include <cstddef>
+
+#include "bluebild/bluebild.h"
+#include "bluebild/config.h"
+#include "context_internal.hpp"
+#include "memory/buffer.hpp"
+#include "host/sensitivity_field_data_host.hpp"
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+#include "gpu/util/gpu_blas_api.hpp"
+#include "gpu/util/gpu_runtime_api.hpp"
+#include "gpu/util/gpu_util.hpp"
+#include "gpu/sensitivity_field_data_gpu.hpp"
+#endif
+
+namespace bluebild {
+
+template <typename T>
+auto sensitivity_field_data(ContextInternal& ctx, T wl, int m, int n, int nEig,
+                            const std::complex<T>* w, int ldw, const T* xyz, int ldxyz, T* d,
+                            std::complex<T>* v, int ldv) -> void {
+  if (ctx.processing_unit() == BLUEBILD_PU_GPU) {
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+        // Syncronize with default stream. TODO: replace with event
+        gpu::stream_synchronize(nullptr);
+
+        BufferType<gpu::ComplexType<T>> wBuffer, vBuffer;
+        BufferType<T> dBuffer, xyzBuffer;
+        auto wDevice = reinterpret_cast<const gpu::ComplexType<T>*>(w);
+        auto vDevice = reinterpret_cast<gpu::ComplexType<T>*>(v);
+        auto xyzDevice = xyz;
+        auto dDevice = d;
+        int ldwDevice = ldw;
+        int ldvDevice = ldv;
+        int ldxyzDevice = ldxyz;
+
+
+        // copy input if required
+        if(!is_device_ptr(w)) {
+          wBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), m * n);
+          ldwDevice = m;
+          wDevice = wBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(
+              wBuffer.get(), m * sizeof(gpu::ComplexType<T>), w, ldw * sizeof(gpu::ComplexType<T>),
+              m * sizeof(gpu::ComplexType<T>), n, gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+        }
+
+        if(!is_device_ptr(xyz)) {
+          xyzBuffer = create_buffer<T>(ctx.allocators().gpu(), 3 * m);
+          ldxyzDevice = m;
+          xyzDevice = xyzBuffer.get();
+          gpu::check_status(gpu::memcpy_2d_async(xyzBuffer.get(), m * sizeof(T), xyz,
+                                                 ldxyz * sizeof(T), m * sizeof(T), 3,
+                                                 gpu::flag::MemcpyDefault, ctx.gpu_stream()));
+        }
+
+        // prepare output
+        if(!is_device_ptr(v)) {
+          vBuffer = create_buffer<gpu::ComplexType<T>>(ctx.allocators().gpu(), nEig * n);
+          ldvDevice = n;
+          vDevice = vBuffer.get();
+        }
+        if(!is_device_ptr(d)) {
+          dBuffer = create_buffer<T>(ctx.allocators().gpu(), nEig);
+          dDevice = dBuffer.get();
+        }
+
+
+        // call intensity_field_data on gpu
+        auto devInfo =
+            sensitivity_field_data_gpu<T>(ctx, wl, m, n, nEig, wDevice, ldwDevice, xyzDevice,
+                                          ldxyzDevice, dDevice, vDevice, ldvDevice);
+
+        if(dBuffer) {
+          gpu::check_status(gpu::memcpy_async(d, dDevice, nEig * sizeof(T),
+                                              gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+        }
+        if(vBuffer) {
+          gpu::check_status(gpu::memcpy_2d_async(
+              v, ldv * sizeof(gpu::ComplexType<T>), vBuffer.get(),
+              ldvDevice * sizeof(gpu::ComplexType<T>), n * sizeof(gpu::ComplexType<T>), nEig,
+              gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+        }
+
+        int hostInfo[2];
+        gpu::check_status(gpu::memcpy_async(hostInfo, devInfo.get(), 2 * sizeof(int),
+                                            gpu::flag::MemcpyDeviceToHost, ctx.gpu_stream()));
+
+        // syncronize with stream to be synchronous with host
+        gpu::check_status(gpu::stream_synchronize(ctx.gpu_stream())); 
+
+        // check if eigensolver threw error
+        if (hostInfo[0] || hostInfo[1]) {
+          throw EigensolverError();
+        }
+#else
+        throw GPUSupportError();
+#endif
+  } else {
+    sensitivity_field_data_host<T>(ctx, wl, m, n, nEig, w, ldw, xyz, ldxyz, d, v, ldv);
+  }
+}
+
+extern "C" {
+BLUEBILD_EXPORT BluebildError bluebild_sensitivity_field_data_s(BluebildContext ctx, float wl,
+                                                                int m, int n, int nEig, void* w,
+                                                                int ldw, const float* xyz,
+                                                                int ldxyz, float* d, void* v,
+                                                                int ldv) {
+  if (!ctx) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    sensitivity_field_data<float>(*reinterpret_cast<ContextInternal*>(ctx), wl, m, n, nEig,
+                                      reinterpret_cast<const std::complex<float>*>(w), ldw, xyz,
+                                      ldxyz, d, reinterpret_cast<std::complex<float>*>(v), ldv);
+  } catch (const bluebild::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+
+BLUEBILD_EXPORT BluebildError bluebild_sensitivity_field_data_d(BluebildContext ctx, double wl,
+                                                                int m, int n, int nEig, void* w,
+                                                                int ldw, const double* xyz,
+                                                                int ldxyz, double* d, void* v,
+                                                                int ldv) {
+  if (!ctx) {
+    return BLUEBILD_INVALID_HANDLE_ERROR;
+  }
+  try {
+    sensitivity_field_data<double>(*reinterpret_cast<ContextInternal*>(ctx), wl, m, n, nEig,
+                                       reinterpret_cast<const std::complex<double>*>(w), ldw, xyz,
+                                       ldxyz, d, reinterpret_cast<std::complex<double>*>(v), ldv);
+  } catch (const bluebild::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BLUEBILD_UNKNOWN_ERROR;
+  }
+  return BLUEBILD_SUCCESS;
+}
+}
+
+}  // namespace bluebild

--- a/src/bluebild/tests/CMakeLists.txt
+++ b/src/bluebild/tests/CMakeLists.txt
@@ -1,0 +1,48 @@
+set(BLUEBILD_TEST_LIBRARIES)
+set(BLUEBILD_TEST_INCLUDE_DIRS)
+
+set(BUILD_GMOCK OFF CACHE BOOL "")
+set(INSTALL_GTEST OFF CACHE BOOL "")
+mark_as_advanced(BUILD_GMOCK INSTALL_GTEST)
+
+include(FetchContent)
+
+# add googletest
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        release-1.11.0
+)
+FetchContent_GetProperties(googletest)
+if(NOT googletest_POPULATED)
+  message(STATUS "Downloading Google Test repository...")
+  FetchContent_Populate(googletest)
+endif()
+add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+list(APPEND BLUEBILD_TEST_LIBRARIES gtest_main)
+
+# add json parser
+set(JSON_Install OFF CACHE BOOL "")
+FetchContent_Declare(
+  json
+  GIT_REPOSITORY https://github.com/nlohmann/json.git
+  GIT_TAG        v3.10.5
+)
+FetchContent_GetProperties(json)
+if(NOT json_POPULATED)
+  message(STATUS "Downloading json repository...")
+  FetchContent_Populate(json)
+endif()
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR})
+list(APPEND BLUEBILD_TEST_LIBRARIES nlohmann_json::nlohmann_json)
+
+
+# test executables
+add_executable(run_tests
+    run_tests.cpp
+    test_lofar.cpp
+    )
+target_link_libraries(run_tests PRIVATE ${BLUEBILD_TEST_LIBRARIES} bluebild_test)
+target_compile_options(run_tests PRIVATE -DBLUEBILD_TEST_DATA_DIR="${CMAKE_CURRENT_LIST_DIR}/data")
+

--- a/src/bluebild/tests/run_tests.cpp
+++ b/src/bluebild/tests/run_tests.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/bluebild/tests/test_lofar.cpp
+++ b/src/bluebild/tests/test_lofar.cpp
@@ -1,0 +1,230 @@
+#include <cmath>
+#include <complex>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+#include <fstream>
+#include <iostream>
+
+#include "bluebild/bluebild.h"
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+
+
+static auto get_lofar_json(int nStation) -> const nlohmann::json& {
+  static nlohmann::json data = []() {
+    std::ifstream file(std::string(BLUEBILD_TEST_DATA_DIR) + "/data_lofar.json");
+    nlohmann::json j;
+    file >> j;
+    return j;
+  }();
+
+  for(const auto& it : data) {
+    if(it["n"] == nStation) return it["data"];
+  }
+  throw std::runtime_error("Failed to find station data in json");
+  return data;
+}
+
+template <typename T, typename JSON>
+static auto read_json_complex_2d(JSON jReal, JSON jImag) -> std::vector<std::complex<T>> {
+  std::vector<std::complex<T>> w;
+
+  auto wRealCol = jReal.begin();
+  auto wImagCol = jImag.begin();
+  for (; wRealCol != jReal.end(); ++wRealCol, ++wImagCol) {
+    auto wReal = wRealCol->begin();
+    auto wImag = wImagCol->begin();
+    for (; wReal != wRealCol->end(); ++wReal, ++wImag) {
+      w.emplace_back(*wReal, *wImag);
+    }
+  }
+  return w;
+}
+
+template <typename T, typename JSON>
+static auto read_json_scalar_2d(JSON j) -> std::vector<T> {
+  std::vector<T> w;
+
+  for (auto &col : j) {
+    for (auto &val : col) {
+      w.emplace_back(val);
+    }
+  }
+
+  return w;
+}
+
+template <typename T>
+class LofarTest : public ::testing::TestWithParam<std::tuple<int, BluebildProcessingUnit>> {
+protected:
+  using ValueType = T;
+
+  LofarTest() : data_(get_lofar_json(std::get<0>(GetParam()))) {
+    if (bluebild_ctx_create(std::get<1>(GetParam()), &ctx_) != BLUEBILD_SUCCESS)
+      throw std::runtime_error("Failed to create context.");
+  }
+
+  auto gram_matrix() -> void {
+    auto wl = ValueType(data_["sensitivity"]["wl"]);
+
+    for (const auto& sensData : data_["sensitivity"]["data"]) {
+      auto m = sensData["XYZ"][0].size();
+      auto n = sensData["G_real"].size();
+      auto xyz = read_json_scalar_2d<ValueType>(sensData["XYZ"]);
+      auto w = read_json_complex_2d<ValueType>(sensData["W_real"], sensData["W_imag"]);
+      auto gRef = read_json_complex_2d<ValueType>(sensData["G_real"], sensData["G_imag"]);
+
+      std::vector<std::complex<ValueType>> g(n * n);
+
+      if (std::is_same<ValueType, float>::value)
+        ASSERT_EQ(bluebild_gram_matrix_s(ctx_, m, n, w.data(), m,
+                                         reinterpret_cast<float*>(xyz.data()), m, wl, g.data(), n),
+                  BLUEBILD_SUCCESS);
+      else
+        ASSERT_EQ(bluebild_gram_matrix_d(ctx_, m, n, w.data(), m,
+                                         reinterpret_cast<double*>(xyz.data()), m, wl, g.data(), n),
+                  BLUEBILD_SUCCESS);
+
+      for (std::size_t i = 0; i < g.size(); ++i) {
+        ASSERT_NEAR(g[i].real(), gRef[i].real(), 10);
+        ASSERT_NEAR(g[i].imag(), gRef[i].imag(), 10);
+      }
+    }
+  }
+
+  auto sensitivity_field_data() -> void {
+    auto wl = ValueType(data_["sensitivity"]["wl"]);
+    auto nEig = int(data_["sensitivity"]["n_eig"]);
+
+    for (const auto& sensData : data_["sensitivity"]["data"]) {
+      auto m = sensData["XYZ"][0].size();
+      auto n = sensData["G_real"].size();
+      auto xyz = read_json_scalar_2d<ValueType>(sensData["XYZ"]);
+      auto w = read_json_complex_2d<ValueType>(sensData["W_real"], sensData["W_imag"]);
+      auto vRef = read_json_complex_2d<ValueType>(sensData["V_real"], sensData["V_imag"]);
+      auto dRef = std::vector<ValueType>(sensData["D"].begin(), sensData["D"].end());
+
+      std::vector<std::complex<ValueType>> v(nEig * n);
+      std::vector<ValueType> d(nEig);
+
+      if (std::is_same<ValueType, float>::value)
+        ASSERT_EQ(bluebild_sensitivity_field_data_s(
+                      ctx_, wl, m, n, nEig, w.data(), m, reinterpret_cast<float*>(xyz.data()), m,
+                      reinterpret_cast<float*>(d.data()), v.data(), n),
+                  BLUEBILD_SUCCESS);
+      else
+        ASSERT_EQ(bluebild_sensitivity_field_data_d(
+                      ctx_, wl, m, n, nEig, w.data(), m, reinterpret_cast<double*>(xyz.data()), m,
+                      reinterpret_cast<double*>(d.data()), v.data(), n),
+                  BLUEBILD_SUCCESS);
+
+      for (std::size_t i = 0; i < d.size(); ++i) {
+        ASSERT_NEAR(d[i], dRef[i], 0.1);
+      }
+
+      for (std::size_t i = 0; i < v.size(); ++i) {
+        // Eigenvectors may be mirrored
+        ASSERT_NEAR(std::abs(v[i].real()), std::abs(vRef[i].real()), 1.0);
+        ASSERT_NEAR(std::abs(v[i].imag()), std::abs(vRef[i].imag()), 1.0);
+      }
+    }
+  }
+
+  auto intensity_field_data() -> void {
+    auto wl = ValueType(data_["intensity"]["wl"]);
+    auto nEig = int(data_["intensity"]["n_eig"]);
+    auto centroid = std::vector<ValueType>(data_["intensity"]["centroid"].begin(),
+                                     data_["intensity"]["centroid"].end());
+
+    for (const auto& intData : data_["intensity"]["data"]) {
+      auto m = intData["XYZ"][0].size();
+      auto n = intData["G_real"].size();
+      auto xyz = read_json_scalar_2d<ValueType>(intData["XYZ"]);
+      auto w = read_json_complex_2d<ValueType>(intData["W_real"], intData["W_imag"]);
+      auto s = read_json_complex_2d<ValueType>(intData["S_real"], intData["S_imag"]);
+      auto vRef = read_json_complex_2d<ValueType>(intData["V_real"], intData["V_imag"]);
+      auto dRef = std::vector<ValueType>(intData["D"].begin(), intData["D"].end());
+      auto cIdxRef = std::vector<int>(intData["c_idx"].begin(), intData["c_idx"].end());
+
+      std::vector<std::complex<ValueType>> v(nEig * n);
+      std::vector<ValueType> d(nEig);
+      std::vector<int> cIdx(nEig);
+
+      if (std::is_same<ValueType, float>::value)
+        ASSERT_EQ(bluebild_intensity_field_data_s(
+                      ctx_, wl, m, n, nEig, s.data(), n, w.data(), m,
+                      reinterpret_cast<float*>(xyz.data()), m, reinterpret_cast<float*>(d.data()),
+                      v.data(), n, centroid.size(), reinterpret_cast<float*>(centroid.data()),
+                      cIdx.data()),
+                  BLUEBILD_SUCCESS);
+      else
+        ASSERT_EQ(bluebild_intensity_field_data_d(
+                      ctx_, wl, m, n, nEig, s.data(), n, w.data(), m,
+                      reinterpret_cast<double*>(xyz.data()), m, reinterpret_cast<double*>(d.data()),
+                      v.data(), n, centroid.size(), reinterpret_cast<double*>(centroid.data()),
+                      cIdx.data()),
+                  BLUEBILD_SUCCESS);
+
+      for (std::size_t i = 0; i < d.size(); ++i) {
+        ASSERT_NEAR(d[i], dRef[i], 2.0);
+      }
+
+      for (std::size_t i = 0; i < v.size(); ++i) {
+        // Eigenvectors may be mirrored
+        ASSERT_NEAR(std::abs(v[i].real()), std::abs(vRef[i].real()), 1.0);
+        ASSERT_NEAR(std::abs(v[i].imag()), std::abs(vRef[i].imag()), 1.0);
+      }
+    }
+  }
+
+  ~LofarTest() {
+    bluebild_ctx_destroy(&ctx_);
+  }
+
+  const nlohmann::json& data_;
+  BluebildContext ctx_;
+};
+
+using LofarSingle = LofarTest<float>;
+using LofarDouble = LofarTest<double>;
+
+TEST_P(LofarSingle, GrammMatrix) { this->gram_matrix(); }
+TEST_P(LofarDouble, GrammMatrix) { this->gram_matrix(); }
+
+
+TEST_P(LofarSingle, Sensitivity) { this->sensitivity_field_data(); }
+TEST_P(LofarDouble, Sensitivity) { this->sensitivity_field_data(); }
+
+TEST_P(LofarSingle, Intensity) { this->intensity_field_data(); }
+TEST_P(LofarDouble, Intensity) { this->intensity_field_data(); }
+
+static auto param_type_names(
+    const ::testing::TestParamInfo<std::tuple<int, BluebildProcessingUnit>>& info) -> std::string {
+  std::stringstream stream;
+
+  if (std::get<1>(info.param) == BLUEBILD_PU_CPU) stream << "CPU_";
+  else stream << "GPU_";
+  stream << "nStation_" << std::get<0>(info.param);
+
+  return stream.str();
+}
+
+#if defined(BLUEBILD_CUDA) || defined(BLUEBILD_ROCM)
+#define TEST_PROCESSING_UNITS BLUEBILD_PU_CPU, BLUEBILD_PU_GPU
+#else
+#define TEST_PROCESSING_UNITS BLUEBILD_PU_CPU
+#endif
+
+INSTANTIATE_TEST_SUITE_P(
+    Lofar, LofarSingle,
+    ::testing::Combine(::testing::Values(8, 24, 48),
+                       ::testing::Values(TEST_PROCESSING_UNITS)),
+    param_type_names);
+
+INSTANTIATE_TEST_SUITE_P(
+    Lofar, LofarDouble,
+    ::testing::Combine(::testing::Values(8, 24, 48),
+                       ::testing::Values(TEST_PROCESSING_UNITS)),
+    param_type_names);


### PR DESCRIPTION
This pull request includes the C++ port of `SensitivityFieldDataProcessorBlock` and `IntensityFieldDataProcessorBlock`.
I've tried to include the build process in the python setup. It seems to work fine for me, but I don't have much expedience with packaging for python.
To show a possible integration, I've modified the nufft example. Most of the other pypeline code remains untouched, so how this is going to be fully integrated might need some discussion.
There are some tests included through GoogleTest with an additional executable. Should this be integrated into the CI?