### PR TITLE
Fixing scale of images produced by Bluebild 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+_skbuild/
 
 # Unit test / coverage reports
 .pytest_cache/

--- a/pypeline/phased_array/bluebild/data_processor.py
+++ b/pypeline/phased_array/bluebild/data_processor.py
@@ -171,7 +171,6 @@ class IntensityFieldDataProcessorBlock(DataProcessorBlock):
 
         # Remove broken BEAM_IDs
         broken_row_id = np.flatnonzero(np.isclose(np.sum(S.data, axis=0), 0))
-        
         if broken_row_id.size:
             working_row_id = list(set(np.arange(N_beam)) - set(broken_row_id))
             idx = np.ix_(working_row_id, working_row_id)
@@ -197,7 +196,6 @@ class IntensityFieldDataProcessorBlock(DataProcessorBlock):
                 # Copied from Imot_Tools but here keeping all eigen pairs (hence no padding/selection required)
                 else:
                     tau = 1
-                    N=self._N_eig
                     try:
                         D, V = linalg.eigh(S, G)
                         idx = np.argsort(D)[::-1]

--- a/pypeline/phased_array/bluebild/data_processor.py
+++ b/pypeline/phased_array/bluebild/data_processor.py
@@ -221,7 +221,7 @@ class IntensityFieldDataProcessorBlock(DataProcessorBlock):
 
         # Add broken BEAM_IDs
         if broken_row_id.size:
-            V_aligned = np.zeros((N_beam, self._N_eig), dtype=V.dtype)
+            V_aligned = np.zeros((N_beam, D.size), dtype=V.dtype)
             V_aligned[working_row_id] = V
         else:
             V_aligned = V

--- a/pypeline/phased_array/bluebild/data_processor.py
+++ b/pypeline/phased_array/bluebild/data_processor.py
@@ -170,7 +170,8 @@ class IntensityFieldDataProcessorBlock(DataProcessorBlock):
         N_beam = len(S.data)
 
         # Remove broken BEAM_IDs
-        broken_row_id = np.flatnonzero(np.isclose(np.sum(S.data, axis=0), np.sum(S.data, axis=1)))
+        broken_row_id = np.flatnonzero(np.isclose(np.sum(S.data, axis=0), 0))
+        
         if broken_row_id.size:
             working_row_id = list(set(np.arange(N_beam)) - set(broken_row_id))
             idx = np.ix_(working_row_id, working_row_id)
@@ -226,9 +227,6 @@ class IntensityFieldDataProcessorBlock(DataProcessorBlock):
             V_aligned[working_row_id] = V
         else:
             V_aligned = V
-
-        # Scale D by the number of non-zero visibilities
-        D /= np.count_nonzero(S.data)
    
         return D, V_aligned, cluster_idx
 

--- a/pypeline/phased_array/bluebild/gram.py
+++ b/pypeline/phased_array/bluebild/gram.py
@@ -177,6 +177,8 @@ class GramBlock(core.Block):
             baseline = linalg.norm(
                 XYZ.reshape(N_antenna, 1, 3) - XYZ.reshape(1, N_antenna, 3), axis=-1
             )
+
+            # Original 4 * pi scale factor removed
             G_1 = np.sinc((2 / wl) * baseline)
             G_2 = W.conj().T @ G_1 @ W
             return G_2

--- a/pypeline/phased_array/bluebild/gram.py
+++ b/pypeline/phased_array/bluebild/gram.py
@@ -177,8 +177,7 @@ class GramBlock(core.Block):
             baseline = linalg.norm(
                 XYZ.reshape(N_antenna, 1, 3) - XYZ.reshape(1, N_antenna, 3), axis=-1
             )
-
-            G_1 = (4 * np.pi) * np.sinc((2 / wl) * baseline)
+            G_1 = np.sinc((2 / wl) * baseline)
             G_2 = W.conj().T @ G_1 @ W
             return G_2
 

--- a/pypeline/phased_array/bluebild/imager/fourier_domain.py
+++ b/pypeline/phased_array/bluebild/imager/fourier_domain.py
@@ -302,7 +302,7 @@ class NUFFT_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
         self._V_collection = []
         self._UVW_collection = []
         self._nbytes = 0
-        self._max_colllect_bytes = max_collect_bytes
+        self._max_collect_bytes = max_collect_bytes
         super(NUFFT_IMFS_Block, self).__init__()
 
     def collect(self, UVW: np.ndarray, V: np.ndarray) -> np.ndarray:
@@ -323,7 +323,7 @@ class NUFFT_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
         self._V_collection.append(V)
         self._UVW_collection.append(UVW)
 
-        if self._nbytes > self._max_colllect_bytes:
+        if self._nbytes > self._max_collect_bytes:
             self._compute()
 
     def as_image(self) -> list:

--- a/pypeline/phased_array/bluebild/imager/spatial_domain.py
+++ b/pypeline/phased_array/bluebild/imager/spatial_domain.py
@@ -122,7 +122,7 @@ class Spatial_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
             wl=chk.is_real, pix_grid=chk.has_reals, N_level=chk.is_integer, precision=chk.is_integer
         )
     )
-    def __init__(self, wl, pix_grid, N_level, precision=64, ctx=None):
+    def __init__(self, wl, pix_grid, N_level, precision=64, ctx=None, filter_negative_eigenvalues=True):
         """
         Parameters
         ----------
@@ -152,7 +152,13 @@ class Spatial_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
 
         if N_level <= 0:
             raise ValueError("Parameter[N_level] must be positive.")
+
+        self._filter_negative_eigenvalues = filter_negative_eigenvalues
+
         self._N_level = N_level
+
+        if not self._filter_negative_eigenvalues:
+            self._N_level += 1
         
         self.timer = None
 

--- a/pypeline/phased_array/bluebild/imager/spatial_domain.py
+++ b/pypeline/phased_array/bluebild/imager/spatial_domain.py
@@ -211,6 +211,10 @@ class Spatial_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
             (2, N_level, N_px) field statistics.
         """
 
+        # Reduce XYZ while in DP
+        assert(XYZ.dtype == np.float64)
+        XYZ = XYZ - np.mean(XYZ, axis=0)
+        
         XYZ = XYZ.astype(self._fp, copy=False)
         D   = D.astype(self._fp, copy=False)
         V   = V.astype(self._cp, copy=False)
@@ -230,7 +234,6 @@ class Spatial_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
             tic = perf_counter()
             assert self._synthesizer._grid.dtype == self._fp, f'_grid {self._grid.dtype} not of expected type {self._fp}'
             stat_std = self._synthesizer(V, XYZ, W)
-                        
             assert stat_std.dtype == self._fp, f'stat_std {stat_std.dtype} not of expected type {self._fp}'
 
             # get result from GPU

--- a/pypeline/phased_array/bluebild/parameter_estimator.py
+++ b/pypeline/phased_array/bluebild/parameter_estimator.py
@@ -19,13 +19,110 @@ Subclasses of :py:class:`~pypeline.phased_array.bluebild.parameter_estimator.Par
 specifically tailored for such tasks.
 """
 
-import imot_tools.math.linalg as pylinalg
+#import imot_tools.math.linalg as pylinalg
 import imot_tools.util.argcheck as chk
 import numpy as np
 import sklearn.cluster as skcl
 import scipy.linalg as linalg
 import pypeline.phased_array.data_gen.statistics as vis
 import pypeline.phased_array.bluebild.gram as gr
+
+
+@chk.check(
+    dict(
+        A=chk.accept_any(chk.has_reals, chk.has_complex),
+        B=chk.allow_None(chk.accept_any(chk.has_reals, chk.has_complex)),
+        tau=chk.is_real,
+        N=chk.allow_None(chk.is_integer),
+    )
+)
+def pylinalg_eigh(A, B=None, tau=1, N=None, check_hermitian=True):
+    """
+    Solve a generalized eigenvalue problem.
+
+    Finds :math:`(D, V)`, solution of the generalized eigenvalue problem
+
+    .. math::
+
+       A V = B V D.
+
+    This function is a wrapper around :py:func:`scipy.linalg.eigh` that adds energy truncation and
+    extra output formats.
+
+    Parameters
+    ----------
+    A : :py:class:`~numpy.ndarray`
+        (M, M) hermitian matrix.
+        If `A` is not positive-semidefinite (PSD), its negative spectrum is discarded.
+    B : :py:class:`~numpy.ndarray`, optional
+        (M, M) PSD hermitian matrix.
+        If unspecified, `B` is assumed to be the identity matrix.
+    tau : float, optional
+        Normalized energy ratio. (Default: 1)
+    N : int, optional
+        Number of eigenpairs to output. (Default: K, the minimum number of leading eigenpairs that
+        account for `tau` percent of the total energy.)
+
+        * If `N` is smaller than K, then the trailing eigenpairs are dropped.
+        * If `N` is greater that K, then the trailing eigenpairs are set to 0.
+
+    Returns
+    -------
+    D : :py:class:`~numpy.ndarray`
+        (N,) positive real-valued eigenvalues.
+
+    V : :py:class:`~numpy.ndarray`
+        (M, N) complex-valued eigenvectors.
+
+        The N eigenpairs are sorted in decreasing eigenvalue order.
+
+    """
+    A = np.array(A, copy=False)
+    M = len(A)
+    if check_hermitian:
+        if not (chk.has_shape([M, M])(A) and np.allclose(A, A.conj().T)):
+            raise ValueError("Parameter[A] must be hermitian symmetric.")
+
+    B = np.eye(M) if (B is None) else np.array(B, copy=False)
+    if not (chk.has_shape([M, M])(B) and np.allclose(B, B.conj().T)):
+        raise ValueError("Parameter[B] must be hermitian symmetric.")
+
+    if not (0 < tau <= 1):
+        raise ValueError("Parameter[tau] must be in [0, 1].")
+
+    if (N is not None) and (N <= 0):
+        raise ValueError(f"Parameter[N] must be a non-zero positive integer.")
+
+    # A: drop negative spectrum.
+    Ds, Vs = linalg.eigh(A)
+    idx = Ds > 0
+    Ds, Vs = Ds[idx], Vs[:, idx]
+    A = (Vs * Ds) @ Vs.conj().T
+
+    # A, B: generalized eigenvalue-decomposition.
+    try:
+        D, V = linalg.eigh(A, B)
+
+        # Discard near-zero D due to numerical precision.
+        idx = D > 0
+        D, V = D[idx], V[:, idx]
+        idx = np.argsort(D)[::-1]
+        D, V = D[idx], V[:, idx]
+    except linalg.LinAlgError:
+        raise ValueError("Parameter[B] is not PSD.")
+
+    # Energy selection / padding
+    idx = np.clip(np.cumsum(D) / np.sum(D), 0, 1) <= tau
+    D, V = D[idx], V[:, idx]
+    if N is not None:
+        M, K = V.shape
+        if N - K <= 0:
+            D, V = D[:N], V[:, :N]
+        else:
+            D = np.concatenate((D, np.zeros(N - K)), axis=0)
+            V = np.concatenate((V, np.zeros((M, N - K))), axis=1)
+
+    return D, V
 
 
 class ParameterEstimator:
@@ -181,7 +278,7 @@ class IntensityFieldParameterEstimator(ParameterEstimator):
         self._visibilities.append(S)
         self._grams.append(G)
 
-    def infer_parameters(self):
+    def infer_parameters(self, check_hermitian=True):
         """
         Estimate parameters given ingested data.
 
@@ -210,7 +307,7 @@ class IntensityFieldParameterEstimator(ParameterEstimator):
             # Functional PCA
             if not np.allclose(S, 0):
                 if self._filter_negative_eigenvalues:
-                    D, _ = pylinalg.eigh(S, G, tau=self._sigma)
+                    D, _ = pylinalg_eigh(S, G, tau=self._sigma, check_hermitian=check_hermitian)
                 # Copied from Imot_Tools but keeping all eigen pairs (=> no padding/selection required)
                 else:
                     try:
@@ -227,8 +324,9 @@ class IntensityFieldParameterEstimator(ParameterEstimator):
 
         # EO: instead of clustering on non-zero eigenvalues, cluster on strictly
         #    positive eigenvalues to also discard negative eigenvalues if kept in.
-        D_all = D_all[D_all > 0.0]
-        kmeans = skcl.KMeans(n_clusters=self._N_level).fit(np.log(D_all).reshape(-1, 1))
+        D_all = np.sort(D_all[D_all > 0.0])
+
+        kmeans = skcl.KMeans(n_clusters=self._N_level, random_state=0).fit(np.log(D_all).reshape(-1, 1))
 
         # For extremely small telescopes or datasets that are mostly 'broken', we can have (N_eig < N_level).
         # In this case we have two options: (N_level = N_eig) or (N_eig = N_level).
@@ -243,7 +341,7 @@ class IntensityFieldParameterEstimator(ParameterEstimator):
 
         if self._filter_negative_eigenvalues:
             N_eig = max(int(np.ceil(len(D_all) / N_data)), self._N_level)
-            
+
         return N_eig, cluster_centroid
 
 
@@ -298,7 +396,7 @@ class SensitivityFieldParameterEstimator(ParameterEstimator):
         for i, G in enumerate(self._grams):
             # Functional PCA
             if self._filter_negative_eigenvalues:
-                D, _ = pylinalg.eigh(G.data, np.eye(N_beam), tau=self._sigma)
+                D, _ = pylinalg_eigh(G.data, np.eye(N_beam), tau=self._sigma)
             else:
                 D = linalg.eigh(G.data, eigvals_only=True)
             D_all[i, : len(D)] = D

--- a/pypeline/phased_array/data_gen/statistics.py
+++ b/pypeline/phased_array/data_gen/statistics.py
@@ -53,26 +53,36 @@ class VisibilityMatrix(array.LabeledMatrix):
             data=chk.accept_any(chk.has_reals, chk.has_complex), beam_idx=beamforming.is_beam_index
         )
     )
-    def __init__(self, data, beam_idx):
-        """
-        Parameters
-        ----------
-        data : array-like(real, complex)
-            (N_beam, N_beam) visibility coefficients.
-        beam_idx
-            (N_beam,) index.
-        """
+
+    def __init__(self, data, beam_idx, check_hermitian=True, weight_spectrum=None):
+
         data = np.array(data, copy=False)
+
+        if weight_spectrum is not None:
+            weight_spectrum = np.array(weight_spectrum, copy=False)
+
         N_beam = len(beam_idx)
 
         if not chk.has_shape((N_beam, N_beam))(data):
             raise ValueError("Parameters[data, beam_idx] are not consistent.")
 
-        if not np.allclose(data, data.conj().T):
-            raise ValueError("Parameter[data] must be hermitian symmetric.")
+        if weight_spectrum is not None:
+            if not chk.has_shape((N_beam, N_beam))(weight_spectrum):
+                raise ValueError("Parameters[weight_spectrum , beam_idx] are not consistent.")
 
-        # Always flag autocorrelation visibilities (i.e. nullify them)
+        if check_hermitian:
+            if not np.allclose(data, data.conj().T):
+                raise ValueError("Parameter[data] must be hermitian symmetric.")
+
+        # Always flag autocorrelation visibilities
         np.fill_diagonal(data, 0)
+        if weight_spectrum is not None:
+            np.fill_diagonal(weight_spectrum, 0)
+
+        # Normalize and apply spectrum weights if provided
+        nz_vis = np.count_nonzero(data)
+        if weight_spectrum is not None:
+            data *= weight_spectrum / np.sum(weight_spectrum) * nz_vis
 
         super().__init__(data, beam_idx, beam_idx)
 

--- a/pypeline/phased_array/data_gen/statistics.py
+++ b/pypeline/phased_array/data_gen/statistics.py
@@ -71,6 +71,9 @@ class VisibilityMatrix(array.LabeledMatrix):
         if not np.allclose(data, data.conj().T):
             raise ValueError("Parameter[data] must be hermitian symmetric.")
 
+        # Always flag autocorrelation visibilities (i.e. nullify them)
+        np.fill_diagonal(data, 0)
+
         super().__init__(data, beam_idx, beam_idx)
 
 

--- a/pypeline/phased_array/measurement_set.py
+++ b/pypeline/phased_array/measurement_set.py
@@ -282,6 +282,11 @@ class MeasurementSet:
             data_flag = sub_table.getcol("FLAG")  # (N_entry, N_channel, 4)
             data = sub_table.getcol(column)  # (N_entry, N_channel, 4)
 
+            try:
+                weight_spectrum = sub_table.getcol("WEIGHT_SPECTRUM")
+            except:
+                weight_spectrum = None
+
             # We only want XX and YY correlations
             data = np.average(data[:, :, [0, 3]], axis=2)[:, channel_id]
             data_flag = np.any(data_flag[:, :, [0, 3]], axis=2)[:, channel_id]
@@ -314,18 +319,37 @@ class MeasurementSet:
             S_fill_in = pd.DataFrame(
                 data=np.zeros((N_diff, len(channel_id)), dtype=data.dtype),
                 columns=channel_id,
-                index=index_diff,
-            )
+                index=index_diff)
             S = pd.concat([S_trunc, S_fill_in], axis=0, ignore_index=False).sort_index(
-                level=["B_0", "B_1"]
-            )
+                level=["B_0", "B_1"])
+            
 
             # Break S into columns and stream out
             t = time.Time(sub_table.calc("MJD(TIME)")[0], format="mjd", scale="utc")
             f = self.channels["FREQUENCY"]
             beam_idx = pd.Index(beam_id, name="BEAM_ID")
+
+            if weight_spectrum is not None:
+                # Mimic WSClean
+                weight = np.min(weight_spectrum[:, :, [0, 3]], axis=2)[:, channel_id]
+                weight[data_flag] = 0
+                W_full = pd.DataFrame(data=weight, columns=channel_id, index=S_full_idx)
+                W_trunc = W_full.drop(index=index_to_drop)
+                W_fill_in = pd.DataFrame(
+                    data=np.zeros((N_diff, len(channel_id)), dtype=weight.dtype),
+                    columns=channel_id,
+                    index=index_diff)
+                W = pd.concat([W_trunc, W_fill_in], axis=0, ignore_index=False).sort_index(
+                    level=["B_0", "B_1"])
+
             for ch_id in channel_id:
                 v = _series2array(S[ch_id].rename("S", inplace=True))
+                nz_vis = np.count_nonzero(v)
+                if nz_vis == 0:
+                    continue
+                if weight_spectrum is not None:
+                    w = _series2array_w(W[ch_id].rename("W", inplace=True))
+                    v *= w / np.sum(w) * nz_vis
                 visibility = vis.VisibilityMatrix(v, beam_idx)
                 yield t, f[ch_id], visibility
 
@@ -356,6 +380,33 @@ def _series2array(visibility: pd.Series) -> np.ndarray:
     S = S + S.conj().T
     S[np.diag_indices_from(S)] = S_diag
     return S
+
+def _series2array_w(weight: pd.Series) -> np.ndarray:
+    b_idx_0 = weight.index.get_level_values("B_0").to_series()
+    b_idx_1 = weight.index.get_level_values("B_1").to_series()
+
+    row_map = (
+        pd.concat(objs=(b_idx_0, b_idx_1), ignore_index=True)
+        .drop_duplicates()
+        .to_frame(name="BEAM_ID")
+        .assign(ROW_ID=lambda df: np.arange(len(df)))
+    )
+    col_map = row_map.rename(columns={"ROW_ID": "COL_ID"})
+
+    data = (
+        weight.reset_index()
+        .merge(row_map, left_on="B_0", right_on="BEAM_ID")
+        .merge(col_map, left_on="B_1", right_on="BEAM_ID")
+        .loc[:, ["ROW_ID", "COL_ID", "W"]]
+    )
+
+    N_beam = len(row_map)
+    W = np.zeros(shape=(N_beam, N_beam), dtype=float)
+    W[data.ROW_ID.values, data.COL_ID.values] = data.W.values
+    W_diag = np.diag(W)
+    W = W + W.T
+    W[np.diag_indices_from(W)] = W_diag
+    return W
 
 
 class LofarMeasurementSet(MeasurementSet):
@@ -531,6 +582,93 @@ class MwaMeasurementSet(MeasurementSet):
         Each dataset has been beamformed in a specific way.
         This property outputs the correct beamformer to compute the beamforming weights.
 
+        Returns
+        -------
+        :py:class:`~pypeline.phased_array.beamforming.MatchedBeamformerBlock`
+            Beamweight computer.
+        """
+        if self._beamformer is None:
+            # MWA does not do any beamforming.
+            # Given the single-antenna station model in MS files from MWA, this can be seen as
+            # Matched-Beamforming, with a single beam output per station.
+            XYZ = self.instrument._layout
+            beam_id = np.unique(XYZ.index.get_level_values("STATION_ID"))
+
+            direction = self.field_center
+            beam_config = [(_, _, direction) for _ in beam_id]
+            self._beamformer = beamforming.MatchedBeamformerBlock(beam_config)
+
+        return self._beamformer
+
+
+class SKALowMeasurementSet(MeasurementSet):
+    """
+    SKA Low Measurement Set reader.
+    """
+    @chk.check(
+        dict(file_name=chk.is_instance(str),
+             N_station=chk.allow_None(chk.is_integer))
+    )
+    def __init__(self, file_name, N_station=None):
+        """
+        Parameters
+        ----------
+        file_name : str
+            Name of the MS file.
+        N_station : int
+            Number of stations to use. (Default = all)
+
+            Sometimes only a subset of an instrument’s stations are desired.
+            Setting `N_station` limits the number of stations to those that appear first when sorted
+            by STATION_ID.
+        """
+        super().__init__(file_name)
+        if N_station is not None:
+            if N_station <= 0:
+                raise ValueError("Parameter[N_station] must be positive.")
+        self._N_station = N_station
+
+    @property
+    def instrument(self):
+        """
+        Returns
+        -------
+        :py:class:`~pypeline.phased_array.instrument.EarthBoundInstrumentGeometryBlock`
+            Instrument position computer.
+        """
+        
+        if self._instrument is None:
+            # Following the MS file specification from https://casa.nrao.edu/casadocs/casa-5.1.0/reference-material/measurement-set,
+            # the ANTENNA sub-table specifies the antenna geometry.
+            # Some remarks on the required fields:
+            # - POSITION: absolute station positions in ITRF coordinates.
+            # - ANTENNA_ID: equivalent to STATION_ID field `InstrumentGeometry.index[0]`
+            #               This field is NOT present in the ANTENNA sub-table, but is given
+            #               implicitly by its row-ordering.
+            #               In other words, the station corresponding to ANTENNA1=k in the MAIN
+            #               table is described by the k-th row of the ANTENNA sub-table.
+            query = f"select POSITION from {self._msf}::ANTENNA"
+            table = ct.taql(query)
+            station_mean = table.getcol("POSITION")
+
+            N_station = len(station_mean)
+            station_id = np.arange(N_station)
+            cfg_idx = pd.MultiIndex.from_product(
+                [station_id, [0]], names=("STATION_ID", "ANTENNA_ID")
+            )
+            cfg = pd.DataFrame(data=station_mean, columns=("X", "Y", "Z"), index=cfg_idx)
+
+            XYZ = instrument.InstrumentGeometry(xyz=cfg.values, ant_idx=cfg.index)
+            
+            self._instrument = instrument.EarthBoundInstrumentGeometryBlock(XYZ)
+
+        return self._instrument
+    
+    @property
+    def beamformer(self):
+        """
+        Each dataset has been beamformed in a specific way.
+        This property outputs the correct beamformer to compute the beamforming weights.
         Returns
         -------
         :py:class:`~pypeline.phased_array.beamforming.MatchedBeamformerBlock`

--- a/pypeline/util/array.py
+++ b/pypeline/util/array.py
@@ -69,7 +69,6 @@ class LabeledMatrix:
                 raise ValueError("Parameter[data] must be CSC/CSR-ordered.")
         else:
             self.__data = np.array(data, copy=False)
-            self.__data.setflags(write=False)
 
             if self.__data.ndim != 2:
                 raise ValueError("Parameter[data] must be 2D.")


### PR DESCRIPTION
I'm opening this PR to discuss an initial solution for correcting the scale of images produced with Bluebild. Once we agree on solution I'll propagate it to the C++ implementations (BIPP and old Bluebild).

The general idea is to add an extra level to contain all negative eigenvalues when it is decided to keep them in. In the pipeline script, to keep them in, you need to add the `filter_negative_eigenvalues=False` argument to the constructors of:
```
I_est = bb_pe.IntensityFieldParameterEstimator(args.nlev, sigma=args.sigma, filter_negative_eigenvalues=False)
I_dp = bb_dp.IntensityFieldDataProcessorBlock(N_eig, c_centroid, ctx, filter_negative_eigenvalues=False)
I_mfs = bb_sd.Spatial_IMFS_Block(wl, px_grid, args.nlev, args.nbits, ctx, filter_negative_eigenvalues=False)
```
So if you asked for 4 clustered levels it will give 5 when `filter_negative_eigenvalues=False`. The clustering on the positive range is kept the same.

The nice thing is that it would allow the user to be able to simply ignore negative eigenvalues by ignoring this last level.

Example:

```
-I- WSClean min, max: -132.480, 1630.422
-I-   Bluebild energy level 0 min, max: 0.000, 1641.157
-I-   Bluebild energy level 1 min, max: 0.010, 128.295
-I-   Bluebild energy level 2 min, max: 0.017, 30.154
-I-   Bluebild energy level 3 min, max: 0.006, 1.157
-I-   Bluebild energy level 4 min, max: -92.559, -0.543
-I- Bluebild cum energy levels [0, 4]: min, max: -82.782, 1642.166
```
